### PR TITLE
Formatting fixes to support PEP8

### DIFF
--- a/lib/base.py
+++ b/lib/base.py
@@ -20,6 +20,7 @@ limitations under the License.
 
 import copy
 
+
 class PybindBase(object):
 
   __slots__ = ()
@@ -47,7 +48,7 @@ class PybindBase(object):
         # this is a YANG container that has its own
         # get method
         d[element_id] = element.get(filter=filter)
-        if filter == True:
+        if filter is True:
           # if the element hadn't changed but we were
           # filtering unchanged elements, remove it
           # from the dictionary
@@ -68,8 +69,8 @@ class PybindBase(object):
       else:
         # this is an attribute that does not have get()
         # method
-        if filter == False and not element._changed():
-          if not element._default == False and element._default:
+        if filter is False and not element._changed():
+          if element._default is not False and element._default:
             d[element_id] = element._default
           else:
             d[element_id] = element

--- a/lib/pybindJSON.py
+++ b/lib/pybindJSON.py
@@ -21,6 +21,7 @@ from serialise import pybindJSONEncoder, pybindJSONDecoder, pybindJSONIOError
 import json
 import copy
 
+
 def remove_path(tree, path):
   this_part = path.pop(0)
   if len(path) == 0:
@@ -38,10 +39,13 @@ def remove_path(tree, path):
   return tree
 
 
-def loads(d, parent_pymod, yang_base, path_helper=None, extmethods=None, overwrite=False):
-  return pybindJSONDecoder().load_json(d, parent_pymod, yang_base, path_helper=path_helper, extmethods=extmethods, overwrite=overwrite)
+def loads(d, parent_pymod, yang_base, path_helper=None, extmethods=None,
+          overwrite=False):
+  return pybindJSONDecoder().load_json(d, parent_pymod, yang_base,
+          path_helper=path_helper, extmethods=extmethods, overwrite=overwrite)
 
-def dumps(obj, indent=4, filter=True, skip_subtrees=[],select=False):
+
+def dumps(obj, indent=4, filter=True, skip_subtrees=[], select=False):
   def lookup_subdict(dictionary, key):
     if not isinstance(key, list):
       raise AttributeError('keys should be a list')
@@ -61,7 +65,7 @@ def dumps(obj, indent=4, filter=True, skip_subtrees=[],select=False):
     # whether they match, then skip the relevant subtrees.
     match = True
     trimmed_path = copy.deepcopy(pp)
-    for i,j in zip(obj._path(), pp):
+    for i, j in zip(obj._path(), pp):
       # paths may have attributes in them, but the skip dictionary does
       # not, so we ensure that the object's absolute path is attribute
       # free,
@@ -72,7 +76,6 @@ def dumps(obj, indent=4, filter=True, skip_subtrees=[],select=False):
         break
       trimmed_path.pop(0)
 
-
     if match and len(trimmed_path):
       tree = remove_path(tree, trimmed_path)
 
@@ -81,25 +84,31 @@ def dumps(obj, indent=4, filter=True, skip_subtrees=[],select=False):
     for t in tree:
       keep = True
       for k, v in select.iteritems():
-        if keep and not unicode(lookup_subdict(tree[t], k.split("."))) == unicode(v):
+        if keep and not \
+                unicode(lookup_subdict(tree[t], k.split("."))) == unicode(v):
           keep = False
       if not keep:
         key_del.append(t)
     for k in key_del:
       del tree[k]
-  return json.dumps(tree,cls=pybindJSONEncoder, indent=indent)
+  return json.dumps(tree, cls=pybindJSONEncoder, indent=indent)
+
 
 def dump(obj, fn, indent=4, filter=True, skip_subtrees=[]):
   try:
     fh = open(fn, 'w')
   except IOError, m:
     raise pybindJSONIOError("could not open file for writing: %s" % m)
-  fh.write(dumps(obj, indent=indent, filter=filter, skip_subtrees=skip_subtrees))
+  fh.write(dumps(obj, indent=indent, filter=filter,
+              skip_subtrees=skip_subtrees))
   fh.close()
 
-def load(fn, parent_pymod, yang_module, path_helper=None, extmethods=None, overwrite=False):
+
+def load(fn, parent_pymod, yang_module, path_helper=None, extmethods=None,
+             overwrite=False):
   try:
     f = json.load(open(fn, 'r'))
   except IOError, m:
     raise pybindJSONIOError("could not open file to read")
-  return loads(f, parent_pymod, yang_module, path_helper=path_helper, extmethods=extmethods, overwrite=overwrite)
+  return loads(f, parent_pymod, yang_module, path_helper=path_helper,
+                extmethods=extmethods, overwrite=overwrite)

--- a/pybind.py
+++ b/pybind.py
@@ -41,73 +41,121 @@ if DEBUG:
 # value, this map is used to provide a mapping of these values to the python
 # True and False boolean instances.
 class_bool_map = {
-  'false':  False,
-  'False':  False,
-  'true':    True,
-  'True':    True,
+    'false': False,
+    'False': False,
+    'true': True,
+    'True': True,
 }
 
 class_map = {
-  # this map is dynamically built upon but defines how we take
-  # a YANG type  and translate it into a native Python class
-  # along with other attributes that are required for this mapping.
-  #
-  # key:                the name of the YANG type
-  # native_type:        the Python class that is used to support this
-  #                     YANG type natively.
-  # map (optional):     a map to take input values and translate them
-  #                     into valid values of the type.
-  # base_type:          whether the class can be used as class(*args, **kwargs)
-  #                     in Python, or whether it is a derived class (such as is
-  #                     created based on a typedef, or for types that cannot be
-  #                     supported natively, such as enumeration, or a string
-  #                     with a restriction placed on it)
-  # quote_arg (opt):    whether the argument to this class' __init__ needs to be
-  #                     quoted (e.g., str("hello")) in the code that is output.
-  # pytype (opt):       A reference to the actual type that is used, this is
-  #                     used where we infer types, such as for an input value to
-  #                     a union since we need to actually compare the value
-  #                     against the __init__ method and see whether it works.
-  # parent_type (opt):  for "derived" types, then we store what the enclosed
-  #                     type is such that we can create instances where required
-  #                     e.g., a restricted string will have a parent_type of a
-  #                     string. this can be a list if the type is a union.
-  # restriction ...:    where the type is a restricted type, then the class_map
-  # (optional)          dict entry can store more information about the type of
-  #                     restriction. this is generally used when we need to
-  #                     re-initialise an instance of the class, such as in the
-  #                     setter methods of containers.
-  # Other types may add their own types to this dictionary that have meaning
-  # only for themselves. For example, a ReferenceType can add the path that it
-  # references, and whether the require-instance keyword was set or not.
-  'boolean':          {"native_type": "YANGBool", "map": class_bool_map,
-                          "base_type": True, "quote_arg": True,
-                            "pytype": YANGBool},
-  'binary':           {"native_type": "bitarray", "base_type": True,
-                          "quote_arg": True, "pytype": bitarray},
-  'uint8':            {"native_type": "np.uint8", "base_type": True,
-                          "pytype": np.uint8},
-  'uint16':           {"native_type": "np.uint16", "base_type": True,
-                          "pytype": np.uint16},
-  'uint32':           {"native_type": "np.uint32", "base_type": True,
-                          "pytype": np.uint32},
-  'uint64':           {"native_type": "np.uint64", "base_type": True,
-                          "pytype": np.uint64},
-  'string':           {"native_type": "unicode", "base_type": True,
-                          "quote_arg": True, "pytype": unicode},
-  'decimal64':        {"native_type": "Decimal", "base_type": True,
-                          "pytype": decimal.Decimal},
-  'empty':            {"native_type": "YANGBool", "map": class_bool_map,
-                          "base_type": True, "quote_arg": True,
-                            "pytype": YANGBool},
-  'int8':             {"native_type": "np.int8", "base_type": True,
-                          "pytype": np.int8},
-  'int16':            {"native_type": "np.int16", "base_type": True,
-                          "pytype": np.int16},
-  'int32':            {"native_type": "np.int32", "base_type": True,
-                          "pytype": np.int32},
-  'int64':            {"native_type": "np.int64", "base_type": True,
-                          "pytype": np.int64},
+    # this map is dynamically built upon but defines how we take
+    # a YANG type  and translate it into a native Python class
+    # along with other attributes that are required for this mapping.
+    #
+    # key:                the name of the YANG type
+    # native_type:        the Python class that is used to support this
+    #                     YANG type natively.
+    # map (optional):     a map to take input values and translate them
+    #                     into valid values of the type.
+    # base_type:          whether the class can be used as
+    #                     class(*args, **kwargs) in Python, or whether it is a
+    #                     derived class (such as is created based on a typedef,
+    #                     or for types that cannot be supported natively, such
+    #                     as enumeration, or a string
+    #                     with a restriction placed on it)
+    # quote_arg (opt):    whether the argument to this class' __init__ needs to
+    #                     be quoted (e.g., str("hello")) in the code that is
+    #                     output.
+    # pytype (opt):       A reference to the actual type that is used, this is
+    #                     used where we infer types, such as for an input
+    #                     value to a union since we need to actually compare
+    #                     the value against the __init__ method and see whether
+    #                     it works.
+    # parent_type (opt):  for "derived" types, then we store what the enclosed
+    #                     type is such that we can create instances where
+    #                     required e.g., a restricted string will have a
+    #                     parent_type of a string. this can be a list if the
+    #                     type is a union.
+    # restriction ...:    where the type is a restricted type, then the
+    # (optional)          class_map dict entry can store more information about
+    #                     the type of restriction. this is generally used when
+    #                     we need to re-initialise an instance of the class,
+    #                     such as in the setter methods of containers.
+    # Other types may add their own types to this dictionary that have
+    # meaning only for themselves. For example, a ReferenceType can add the
+    # path it references, and whether the require-instance keyword was set
+    # or not.
+    #
+    'boolean': {
+        "native_type": "YANGBool",
+        "map": class_bool_map,
+        "base_type": True,
+        "quote_arg": True,
+        "pytype": YANGBool
+    },
+    'binary': {
+        "native_type": "bitarray",
+        "base_type": True,
+        "quote_arg": True,
+        "pytype": bitarray
+    },
+    'uint8': {
+        "native_type": "np.uint8",
+        "base_type": True,
+        "pytype": np.uint8
+    },
+    'uint16': {
+        "native_type": "np.uint16",
+        "base_type": True,
+        "pytype": np.uint16
+    },
+    'uint32': {
+        "native_type": "np.uint32",
+        "base_type": True,
+        "pytype": np.uint32
+    },
+    'uint64': {
+        "native_type": "np.uint64",
+        "base_type": True,
+        "pytype": np.uint64},
+    'string': {
+        "native_type": "unicode",
+        "base_type": True,
+        "quote_arg": True,
+        "pytype": unicode
+    },
+    'decimal64': {
+        "native_type": "Decimal",
+        "base_type": True,
+        "pytype": decimal.Decimal
+    },
+    'empty': {
+        "native_type": "YANGBool",
+        "map": class_bool_map,
+        "base_type": True,
+        "quote_arg": True,
+        "pytype": YANGBool
+    },
+    'int8': {
+        "native_type": "np.int8",
+        "base_type": True,
+        "pytype": np.int8
+    },
+    'int16': {
+        "native_type": "np.int16",
+        "base_type": True,
+        "pytype": np.int16
+    },
+    'int32': {
+        "native_type": "np.int32",
+        "base_type": True,
+        "pytype": np.int32
+    },
+    'int64': {
+        "native_type": "np.int64",
+        "base_type": True,
+        "pytype": np.int64
+    },
 }
 
 # We have a set of types which support "range" statements in RFC6020. This
@@ -116,12 +164,12 @@ INT_RANGE_TYPES = ["uint8", "uint16", "uint32", "uint64",
                     "int8", "int16", "int32", "int64"]
 
 
-
 # Base machinery to support operation as a plugin to pyang.
 def pyang_plugin_init():
-    plugin.register_plugin(BTPyClass())
+    plugin.register_plugin(PyangBindClass())
 
-class BTPyClass(plugin.PyangPlugin):
+
+class PyangBindClass(plugin.PyangPlugin):
     def add_output_format(self, fmts):
       # Add the 'pybind' output format to pyang.
       self.multiple_modules = True
@@ -134,61 +182,61 @@ class BTPyClass(plugin.PyangPlugin):
     def add_opts(self, optparser):
       # Add pyangbind specific operations to pyang. These are documented in the
       # options, but are essentially divided into three sets.
-      #   * xpathhelper - How pyangbind should deal with xpath expressions. This
-      #     module is documented in lib/xpathhelper and describes how support
-      #     registration, updates, and retrieval of xpaths.
-      #   * class output - whether a single file should be created, or whether a
-      #     hierarchy of python modules should be created. The latter is
+      #   * xpathhelper - How pyangbind should deal with xpath expressions.
+      #     This module is documented in lib/xpathhelper and describes how
+      #     to support registration, updates, and retrieval of xpaths.
+      #   * class output - whether a single file should be created, or whether
+      #     a hierarchy of python modules should be created. The latter is
       #     preferable when one has large trees being compiled.
       #   * extensions - support for YANG extensions that pyangbind should look
       #     for, and add as a dictionary with each element.
       optlist = [
-                  optparse.make_option("--use-xpathhelper",
-                                       dest="use_xpathhelper",
-                                       action="store_true",
-                                       help="""Use the xpathhelper module to
-                                               resolve leafrefs"""),
-                  optparse.make_option("--split-class-dir",
-                                       metavar="DIR",
-                                       dest="split_class_dir",
-                                       help="""Split the code output into
-                                               multiple directories"""),
-                  optparse.make_option("--pybind-class-dir",
-                                        metavar="DIR",
-                                        dest="pybind_class_dir",
-                                        help="""Path in which the pyangbind
-                                                'lib' directionary can be found
-                                                - assumed to be the local
-                                                directory if this option
-                                                is not specified"""),
-                  optparse.make_option("--interesting-extension",
-                                      metavar="EXTENSION-MODULE",
-                                      default=[],
-                                      action="append",
-                                      type=str,
-                                      dest="pybind_interested_exts",
-                                      help="""A set of extensions that
-                                              are interesting and should be
-                                              stored with the class. They
-                                              can be accessed through the
-                                              "extension_dict()" argument.
-                                              Multiple arguments can be
-                                              specified."""),
-                  optparse.make_option("--use-extmethods",
-                                      dest="use_extmethods",
-                                      action="store_true",
-                                      help="""Allow a path-keyed dictionary
-                                              to be used to specify methods
-                                              related to a particular class"""),
-                ]
+          optparse.make_option("--use-xpathhelper",
+                               dest="use_xpathhelper",
+                               action="store_true",
+                               help="""Use the xpathhelper module to
+                                       resolve leafrefs"""),
+          optparse.make_option("--split-class-dir",
+                               metavar="DIR",
+                               dest="split_class_dir",
+                               help="""Split the code output into
+                                       multiple directories"""),
+          optparse.make_option("--pybind-class-dir",
+                                metavar="DIR",
+                                dest="pybind_class_dir",
+                                help="""Path in which the pyangbind
+                                        'lib' directionary can be found
+                                        - assumed to be the local
+                                        directory if this option
+                                        is not specified"""),
+          optparse.make_option("--interesting-extension",
+                              metavar="EXTENSION-MODULE",
+                              default=[],
+                              action="append",
+                              type=str,
+                              dest="pybind_interested_exts",
+                              help="""A set of extensions that
+                                      are interesting and should be
+                                      stored with the class. They
+                                      can be accessed through the
+                                      "extension_dict()" argument.
+                                      Multiple arguments can be
+                                      specified."""),
+          optparse.make_option("--use-extmethods",
+                              dest="use_extmethods",
+                              action="store_true",
+                              help="""Allow a path-keyed dictionary
+                                      to be used to specify methods
+                                      related to a particular class"""),
+      ]
       g = optparser.add_option_group("pyangbind output specific options")
       g.add_options(optlist)
+
 
 # Core function to build the pyangbind output - starting with building the
 # dependencies - and then working through the instantiated tree that pyang has
 # already parsed.
 def build_pybind(ctx, modules, fd):
-
   # Restrict the output of the plugin to only the modules that are supplied
   # to pyang. More modules are parsed by pyangbind to resolve typedefs and
   # identities.
@@ -203,7 +251,7 @@ def build_pybind(ctx, modules, fd):
   if len(ctx.errors):
     for e in ctx.errors:
       if not e[1] in ["UNUSED_IMPORT", "PATTERN_ERROR"]:
-        sys.stderr.write("FATAL: pyangbind cannot build module that pyang" + \
+        sys.stderr.write("FATAL: pyangbind cannot build module that pyang" +
           " has found errors with.\n")
         sys.exit(127)
 
@@ -245,16 +293,17 @@ def build_pybind(ctx, modules, fd):
   for module in modules:
     local_module_prefix = module.search_one('prefix')
     if local_module_prefix is None:
-      local_module_prefix = module.search_one('belongs-to').search_one('prefix')
+      local_module_prefix = \
+          module.search_one('belongs-to').search_one('prefix')
       if local_module_prefix is None:
-        raise AttributeError("A module (%s) must have a prefix or parent " + \
+        raise AttributeError("A module (%s) must have a prefix or parent " +
           "module")
       local_module_prefix = local_module_prefix.arg
     else:
       local_module_prefix = local_module_prefix.arg
-    mods = [(local_module_prefix,module)]
-    # 'include' statements specify the submodules of the existing module - which
-    # also need to be parsed.
+    mods = [(local_module_prefix, module)]
+    # 'include' statements specify the submodules of the existing module -
+    # that also need to be parsed.
     for i in module.search('include'):
       subm = ctx.get_module(i.arg)
       if subm is not None:
@@ -272,10 +321,9 @@ def build_pybind(ctx, modules, fd):
   # remove duplicates from the list (same module and prefix)
   new_all_mods = []
   for mod in all_mods:
-    if not mod in new_all_mods:
+    if mod not in new_all_mods:
       new_all_mods.append(mod)
   all_mods = new_all_mods
-
 
   # Build a list of the 'typedef' and 'identity' statements that are included
   # in the modules supplied.
@@ -285,7 +333,7 @@ def build_pybind(ctx, modules, fd):
     for m in all_mods:
       t = find_definitions(defnt, ctx, m[1], m[0])
       for k in t:
-        if not k in defn[defnt]:
+        if k not in defn[defnt]:
           defn[defnt][k] = t[k]
 
   # Build the identities and typedefs (these are added to the class_map which
@@ -306,6 +354,7 @@ def build_pybind(ctx, modules, fd):
       children = [ch for ch in module.i_children
             if ch.keyword in statements.data_definition_keywords]
       get_children(ctx, fd, children, m, m)
+
 
 def build_identities(ctx, defnd):
   # Build dicionaries which determine how identities work. Essentially, an
@@ -336,25 +385,25 @@ def build_identities(ctx, defnd):
         # define it as both the resolved value (i.e., with the prefix)
         # and the unresolved value.
         if ":" in ident:
-          prefix,value = ident.split(":")
-          prefix,value = unicode(prefix),unicode(value)
-          if not value in identity_d[base_id]:
+          prefix, value = ident.split(":")
+          prefix, value = unicode(prefix), unicode(value)
+          if value not in identity_d[base_id]:
             identity_d[base_id][value] = {}
-          if not value in identity_d:
+          if value not in identity_d:
             identity_d[value] = {}
           # check whether the base existed with the prefix that was
           # used for this value too, as long as the base_id is not
           # already resolved
-          if not ":" in base_id:
+          if ":" not in base_id:
             resolved_base = unicode("%s:%s" % (prefix, base_id))
-            if not resolved_base in identity_d:
+            if resolved_base not in identity_d:
               reprocess = True
             else:
               identity_d[resolved_base][ident] = {}
               identity_d[resolved_base][value] = {}
-        if not ident in identity_d[base_id]:
+        if ident not in identity_d[base_id]:
           identity_d[base_id][ident] = {}
-        if not ident in identity_d:
+        if ident not in identity_d:
           identity_d[ident] = {}
       else:
         reprocess = True
@@ -364,18 +413,17 @@ def build_identities(ctx, defnd):
         # around many times, we can't find a base for the identity, which means
         # it is invalid.
         if unresolved_idc[ident] > 1000:
-          sys.stderr.write("could not find a match for %s base: %s\n" % \
+          sys.stderr.write("could not find a match for %s base: %s\n" %
             (ident, base.arg))
           error_ids.append(ident)
         else:
           unresolved_ids.append(ident)
           unresolved_idc[ident] += 1
 
-
   # Remove those identities that do not have any members. This would remove
   # identities that are solely bases, but have no other members. However, this
   # is a problem if particular modules are compiled.
-  #for potential_identity in identity_d.keys():
+  # for potential_identity in identity_d.keys():
   #  if len(identity_d[potential_identity]) == 0:
   #    del identity_d[potential_identity]
 
@@ -385,14 +433,15 @@ def build_identities(ctx, defnd):
   # Add entries to the class_map such that this identity can be referenced by
   # elements that use this identity ref.
   for i in identity_d:
-    id_type = {"native_type": """RestrictedClassType(base_type=unicode, """ + \
-                              """restriction_type="dict_key", """ + \
-                              """restriction_arg=%s,)""" % identity_d[i], \
-                "restriction_argument": identity_d[i], \
+    id_type = {"native_type": """RestrictedClassType(base_type=unicode, """ +
+                              """restriction_type="dict_key", """ +
+                              """restriction_arg=%s,)""" % identity_d[i],
+                "restriction_argument": identity_d[i],
                 "restriction_type": "dict_key",
                 "parent_type": "string",
-                "base_type": False,}
+                "base_type": False}
     class_map[i] = id_type
+
 
 def build_typedefs(ctx, defnd):
   # Build the type definitions that are specified within a model. Since
@@ -415,14 +464,14 @@ def build_typedefs(ctx, defnd):
     if base_t.arg == "union":
       subtypes = [i for i in base_t.search('type')]
     elif base_t.arg == "identityref":
-      subtypes = [base_t.search_one('base'),]
+      subtypes = [base_t.search_one('base')]
     else:
-      subtypes = [base_t,]
+      subtypes = [base_t]
 
     any_unknown = False
     for i in subtypes:
-      if not i.arg in known_types:
-        any_unknown=True
+      if i.arg not in known_types:
+        any_unknown = True
     if not any_unknown:
       process_typedefs_ordered.append((t, defnd[t]))
       known_types.append(t)
@@ -433,8 +482,8 @@ def build_typedefs(ctx, defnd):
         # typedef that has a type in it that is not found after many iterations
         # then we should bail.
         error_ids.append(t)
-        sys.stderr.write("could not find a match for %s type -> %s\n" % \
-          (t,[i.arg for i in subtypes]))
+        sys.stderr.write("could not find a match for %s type -> %s\n" %
+          (t, [i.arg for i in subtypes]))
       else:
         unresolved_t.append(t)
 
@@ -449,7 +498,7 @@ def build_typedefs(ctx, defnd):
     restricted_arg = False
     # Copy the class_map entry - this is done so that we do not alter the
     # existing instance in memory as we add to it.
-    cls,elemtype = copy.deepcopy(build_elemtype(ctx, item.search_one('type')))
+    cls, elemtype = copy.deepcopy(build_elemtype(ctx, item.search_one('type')))
     known_types = class_map.keys()
     # Enumeration is a native type, but is not natively supported
     # in the class_map, and hence we append it here.
@@ -463,19 +512,19 @@ def build_typedefs(ctx, defnd):
 
     # 'elemtype' is a list when the type includes a union, so we need to go
     # through and build a type definition that supports multiple types.
-    if not isinstance(elemtype,list):
+    if not isinstance(elemtype, list):
       restricted = False
       # Map the original type to the new type, parsing the additional arguments
       # that may be specified, for example, a new default, a pattern that must
       # be matched, or a length (stored in the restriction_argument, and
       # restriction_type class_map variables).
-      class_map[type_name] = {"base_type": False,}
+      class_map[type_name] = {"base_type": False}
       class_map[type_name]["native_type"] = elemtype["native_type"]
       if "parent_type" in elemtype:
         class_map[type_name]["parent_type"] = elemtype["parent_type"]
       else:
         yang_type = item.search_one('type').arg
-        if not yang_type in known_types:
+        if yang_type not in known_types:
           raise TypeError("typedef specified a native type that was not " +
                             "supported")
         class_map[type_name]["parent_type"] = yang_type
@@ -488,7 +537,7 @@ def build_typedefs(ctx, defnd):
         class_map[type_name]["require_instance"] = elemtype["require_instance"]
       if "restriction_type" in elemtype:
         class_map[type_name]["restriction_type"] = \
-                                              elemtype["restriction_type"]
+            elemtype["restriction_type"]
         class_map[type_name]["restriction_argument"] = \
                                               elemtype["restriction_argument"]
       if "quote_arg" in elemtype:
@@ -517,10 +566,11 @@ def build_typedefs(ctx, defnd):
           q = True if "quote_arg" in i[1] else False
           default = (i[1]["default"], q)
       class_map[type_name] = {"native_type": native_type, "base_type": False,
-                              "parent_type": parent_type,}
+                              "parent_type": parent_type}
       if default:
         class_map[type_name]["default"] = default[0]
         class_map[type_name]["quote_default"] = default[1]
+
 
 def find_child_definitions(obj, defn, prefix, definitions):
   for i in obj.search(defn):
@@ -536,19 +586,21 @@ def find_child_definitions(obj, defn, prefix, definitions):
 
   return definitions
 
+
 def find_definitions(defn, ctx, module, prefix):
   # Find the statements within a module that map to a particular type of
   # statement, for instance - find typedefs, or identities, and reutrn them
   # as a dictionary to the calling function.
   mod = ctx.get_module(module.arg)
   if mod is None:
-    raise AttributeError("expected to be able to find module %s, " % \
+    raise AttributeError("expected to be able to find module %s, " %
                         (module.arg) + "but could not")
   definitions = {}
   defin = find_child_definitions(mod, defn, prefix, definitions)
   return defin
 
-def get_children(ctx, fd, i_children, module, parent, path=str(), \
+
+def get_children(ctx, fd, i_children, module, parent, path=str(),
                  parent_cfg=True, choice=False):
   # Iterative function that is called for all elements that have childen
   # data nodes in the tree. This function resolves those nodes into the
@@ -557,7 +609,7 @@ def get_children(ctx, fd, i_children, module, parent, path=str(), \
   # ensure that where a parent container was set to config false, this is
   # inherited by all elements below it; and choice is used to store whether
   # these leaves are within a choice or not.
-  used_types,elements = [],[]
+  used_types, elements = [], []
   choices = False
 
   # When pyangbind was asked to split classes, then we need to create the
@@ -572,8 +624,8 @@ def get_children(ctx, fd, i_children, module, parent, path=str(), \
 
       # Check that we don't have the problem of containers that are nested
       # with the same name
-      for i in range(1,len(pparts)):
-        if i > 0 and pparts[i] == pparts[i-1]:
+      for i in range(1, len(pparts)):
+        if i > 0 and pparts[i] == pparts[i - 1]:
           pname = safe_name(pparts[i]) + "_"
         elif i == 1 and pparts[i] == module.arg:
           pname = safe_name(pparts[i]) + "_"
@@ -589,13 +641,13 @@ def get_children(ctx, fd, i_children, module, parent, path=str(), \
       try:
         nfd = open(fpath, 'w')
       except IOError, m:
-        raise IOError, "could not open pyangbind output file (%s)" % m
+        raise IOError("could not open pyangbind output file (%s)" % m)
       nfd.write(ctx.pybind_common_hdr)
     else:
       try:
         nfd = open(fpath, 'a')
       except IOError, w:
-        raise IOError, "could not open pyangbind output file (%s)" % m
+        raise IOError("could not open pyangbind output file (%s)" % m)
   else:
     # If we weren't asked to split the files, then just use the file handle
     # provided.
@@ -624,11 +676,11 @@ def get_children(ctx, fd, i_children, module, parent, path=str(), \
       for choice_ch in ch.i_children:
         # these are case statements
         for case_ch in choice_ch.i_children:
-          elements += get_element(ctx, fd, case_ch, module, parent, \
-            path+"/"+ch.arg, parent_cfg=parent_cfg, \
-            choice=(ch.arg,choice_ch.arg))
+          elements += get_element(ctx, fd, case_ch, module, parent,
+            path + "/" + ch.arg, parent_cfg=parent_cfg,
+            choice=(ch.arg, choice_ch.arg))
     else:
-      elements += get_element(ctx, fd, ch, module, parent, path+"/"+ch.arg,\
+      elements += get_element(ctx, fd, ch, module, parent, path + "/" + ch.arg,
         parent_cfg=parent_cfg, choice=choice)
       if ctx.opts.split_class_dir:
         if hasattr(ch, "i_children") and len(ch.i_children):
@@ -649,7 +701,7 @@ def get_children(ctx, fd, i_children, module, parent, path=str(), \
       nfd.write("class %s(PybindBase):\n" % safe_name(parent.arg))
     else:
       if not path == "":
-        nfd.write("class yc_%s_%s_%s(PybindBase):\n" % (safe_name(parent.arg), \
+        nfd.write("class yc_%s_%s_%s(PybindBase):\n" % (safe_name(parent.arg),
           safe_name(module.arg), safe_name(path.replace("/", "_"))))
       else:
         nfd.write("class %s(PybindBase):\n" % safe_name(parent.arg))
@@ -659,11 +711,11 @@ def get_children(ctx, fd, i_children, module, parent, path=str(), \
     keyval = False
     if parent.keyword == "list":
       keyval = parent.search_one('key').arg if parent.search_one('key') \
-                                    is not None else False
+          is not None else False
       if keyval and " " in keyval:
         keyval = keyval.split(" ")
       else:
-        keyval = [keyval,]
+        keyval = [keyval]
 
     # Auto-generate a docstring based on the description that is provided in
     # the YANG module. This aims to provide readability to someone perusing the
@@ -671,7 +723,7 @@ def get_children(ctx, fd, i_children, module, parent, path=str(), \
     parent_descr = parent.search_one('description')
     if parent_descr is not None:
       parent_descr = "\n\n  YANG Description: %s" % \
-        parent_descr.arg.decode('utf8').encode('ascii', 'ignore')
+          parent_descr.arg.decode('utf8').encode('ascii', 'ignore')
     else:
       parent_descr = ""
 
@@ -681,7 +733,7 @@ def get_children(ctx, fd, i_children, module, parent, path=str(), \
   from YANG module %s - based on the path %s. Each member element of
   the container is represented as a class variable - with a specific
   YANG type.%s
-  """\n''' % (module.arg, (path if not path == "" else "/%s" % parent.arg), \
+  """\n''' % (module.arg, (path if not path == "" else "/%s" % parent.arg),
               parent_descr))
   else:
     raise TypeError("unhandled keyword with children %s" % parent.keyword)
@@ -696,10 +748,11 @@ def get_children(ctx, fd, i_children, module, parent, path=str(), \
     # Doing so gives an AttributeError when a user tries to specify something
     # that was not in the model.
     elements_str = "_pyangbind_elements = {"
-    slots_str = "  __slots__ = ('_pybind_generated_by', '_path_helper', '_yang_name', '_extmethods', "
+    slots_str = "  __slots__ = ('_pybind_generated_by', '_path_helper',"
+    slots_str += " '_yang_name', '_extmethods', "
     for i in elements:
       slots_str += "'__%s'," % i["name"]
-      elements_str +=  "'%s': %s, " % (i["name"], i["name"])
+      elements_str += "'%s': %s, " % (i["name"], i["name"])
     slots_str += ")\n"
     elements_str += "}\n"
     nfd.write(slots_str + "\n")
@@ -722,7 +775,7 @@ def get_children(ctx, fd, i_children, module, parent, path=str(), \
       class_str = {}
       if "default" in i and not i["default"] is None:
         default_arg = "\"%s\"" % (i["default"]) if i["quote_arg"] else "%s" \
-                                    % i["default"]
+            % i["default"]
 
       if i["class"] == "leaf-list":
         # Map a leaf-list to the type specified in the class map. This is a
@@ -738,9 +791,9 @@ def get_children(ctx, fd, i_children, module, parent, path=str(), \
         else:
           allowed_type = "%s" % (i["type"]["native_type"][1])
         class_str["arg"] += "%s(allowed_type=%s)" % \
-          (i["type"]["native_type"][0],allowed_type)
+          (i["type"]["native_type"][0], allowed_type)
         if "default" in i and not i["default"] is None:
-          class_str["arg"] += ", default=%s(%s)" % (i["defaulttype"], \
+          class_str["arg"] += ", default=%s(%s)" % (i["defaulttype"],
             default_arg)
       elif i["class"] == "list":
         # Map a list to YANGList class - this is dynamically derived by the
@@ -749,9 +802,10 @@ def get_children(ctx, fd, i_children, module, parent, path=str(), \
         class_str["name"] = "__%s" % (i["name"])
         class_str["type"] = "YANGDynClass"
         class_str["arg"] = "base=YANGListType("
-        class_str["arg"] += "%s,%s" % ("\"%s\"" % i["key"] if i["key"] \
+        class_str["arg"] += "%s,%s" % ("\"%s\"" % i["key"] if i["key"]
                                                   else False, i["type"])
-        class_str["arg"] += ", yang_name=\"%s\", parent=self" % (i["yang_name"])
+        class_str["arg"] += ", yang_name=\"%s\", parent=self" \
+            % (i["yang_name"])
         class_str["arg"] += ", is_container='list', user_ordered=%s" \
                                                   % i["user_ordered"]
         class_str["arg"] += ", path_helper=self._path_helper"
@@ -759,10 +813,10 @@ def get_children(ctx, fd, i_children, module, parent, path=str(), \
           class_str["arg"] += ", choice=%s" % repr(choice)
         class_str["arg"] += ")"
       elif i["class"] == "union" or i["class"] == "leaf-union":
-        # A special mapped type where there is a union that just includes leaves
-        # this is mapped to a particular Union type, and valid types within it
-        # provided. The dynamically generated class will determine whether the
-        # input can be mapped to the types included in the union.
+        # A special mapped type where there is a union that just includes
+        # leaves this is mapped to a particular Union type, and valid types
+        # within it. The dynamically generated class will determine whether
+        # the input can be mapped to the types included in the union.
         class_str["name"] = "__%s" % (i["name"])
         class_str["type"] = "YANGDynClass"
         class_str["arg"] = "base=["
@@ -774,7 +828,7 @@ def get_children(ctx, fd, i_children, module, parent, path=str(), \
             class_str["arg"] += "%s," % u[1]["native_type"]
         class_str["arg"] += "]"
         if "default" in i and not i["default"] is None:
-          class_str["arg"] += ", default=%s(%s)" % (i["defaulttype"], \
+          class_str["arg"] += ", default=%s(%s)" % (i["defaulttype"],
             default_arg)
       elif i["class"] == "leafref":
         # A leafref, pyangbind uses the special ReferenceType which performs a
@@ -791,12 +845,12 @@ def get_children(ctx, fd, i_children, module, parent, path=str(), \
         # Deal with the special case of a list of leafrefs, since the
         # ReferenceType has different arguments that need to be provided to the
         # class to properly initialise.
-        class_str["name"] = "__%s"% (i["name"])
+        class_str["name"] = "__%s" % (i["name"])
         class_str["type"] = "YANGDynClass"
         class_str["arg"] = "base=%s" % i["type"]["native_type"][0]
         class_str["arg"] += "(allowed_type=%s(referenced_path='%s'," \
-                              % (i["type"]["native_type"][1]["native_type"], \
-                                 i["type"]["native_type"][1]["referenced_path"])
+                              % (i["type"]["native_type"][1]["native_type"],
+                                i["type"]["native_type"][1]["referenced_path"])
         class_str["arg"] += "caller=self._path() + ['%s'], " % i["yang_name"]
         class_str["arg"] += "path_helper=self._path_helper, "
         class_str["arg"] += "require_instance=%s))" % \
@@ -805,7 +859,7 @@ def get_children(ctx, fd, i_children, module, parent, path=str(), \
         # Generically handle all other classes with the 'standard' mappings.
         class_str["name"] = "__%s" % (i["name"])
         class_str["type"] = "YANGDynClass"
-        if isinstance(i["type"],list):
+        if isinstance(i["type"], list):
           class_str["arg"] = "base=["
           for u in i["type"]:
             class_str["arg"] += "%s," % u
@@ -813,7 +867,7 @@ def get_children(ctx, fd, i_children, module, parent, path=str(), \
         else:
           class_str["arg"] = "base=%s" % i["type"]
         if "default" in i and not i["default"] is None:
-          class_str["arg"] += ", default=%s(%s)" % (i["defaulttype"], \
+          class_str["arg"] += ", default=%s(%s)" % (i["defaulttype"],
                                                         default_arg)
       if i["class"] == "container":
         class_str["arg"] += ", is_container='container'"
@@ -843,8 +897,9 @@ def get_children(ctx, fd, i_children, module, parent, path=str(), \
         classes[i["name"]] = class_str
 
     # TODO: get and set methods currently have errors that are reported that
-    # are a bit ugly. The intention here is to act like an immutable type - such
-    # that new class instances are created each time that the value is set.
+    # are a bit ugly. The intention here is to act like an immutable type -
+    # such that new class instances are created each time that the value is
+    # set.
 
     # Generic class __init__, set up the path_helper if asked to.
     nfd.write("""
@@ -886,7 +941,7 @@ def get_children(ctx, fd, i_children, module, parent, path=str(), \
     # Write out the classes that are stored locally as self.__foo where
     # foo is the safe YANG name.
     for c in classes:
-      nfd.write("    self.%s = %s(%s)\n" % (classes[c]["name"], \
+      nfd.write("    self.%s = %s(%s)\n" % (classes[c]["name"],
                                   classes[c]["type"], classes[c]["arg"]))
     # Don't accept arguments to a container/list/submodule class
     nfd.write("""
@@ -921,7 +976,7 @@ def get_children(ctx, fd, i_children, module, parent, path=str(), \
       description_str = ""
       if i["description"]:
         description_str = "\n\n    YANG Description: %s" \
-              % i["description"].decode('utf-8').encode('ascii', 'ignore')
+            % i["description"].decode('utf-8').encode('ascii', 'ignore')
       nfd.write('''
   def _get_%s(self):
     """
@@ -939,8 +994,9 @@ def get_children(ctx, fd, i_children, module, parent, path=str(), \
     source YANG file, then _set_%s is considered as a private
     method. Backends looking to populate this variable should
     do so via calling thisObj._set_%s() directly.%s
-    """''' % (i["name"], i["name"], i["path"], \
-                          i["origtype"], i["name"], i["name"], description_str,))
+    """''' % (i["name"], i["name"], i["path"],
+                          i["origtype"], i["name"], i["name"],
+                          description_str))
       nfd.write("""
     try:
       t = %s(v,%s)""" % (c_str["type"], c_str["arg"]))
@@ -957,7 +1013,8 @@ def get_children(ctx, fd, i_children, module, parent, path=str(), \
       # the object is required.
       nfd.write("""
   def _unset_%s(self):
-    self.__%s = %s(%s)\n\n""" % (i["name"], i["name"], c_str["type"], c_str["arg"],))
+    self.__%s = %s(%s)\n\n""" % (i["name"], i["name"],
+                                  c_str["type"], c_str["arg"],))
 
     # When an element is read-only, write out the _set and _get methods, but
     # we don't actually make the property object accessible. This ensures that
@@ -975,7 +1032,7 @@ def get_children(ctx, fd, i_children, module, parent, path=str(), \
       if not rw:
         nfd.write("""  %s = property(_get_%s)\n""" % (i["name"], i["name"]))
       else:
-        nfd.write("""  %s = property(_get_%s, _set_%s)\n""" % \
+        nfd.write("""  %s = property(_get_%s, _set_%s)\n""" %
                           (i["name"], i["name"], i["name"]))
   nfd.write("\n")
 
@@ -991,12 +1048,13 @@ def get_children(ctx, fd, i_children, module, parent, path=str(), \
 
   return None
 
+
 def build_elemtype(ctx, et, prefix=False):
   # Build a dictionary which defines the type for the element. This is used
   # both in the case that a typedef needs to be built, as well as on per-list
   # basis.
   cls = None
-  pattern_stmt =  et.search_one('pattern') if not et.search_one('pattern') \
+  pattern_stmt = et.search_one('pattern') if not et.search_one('pattern') \
                                               is None else False
   range_stmt = et.search_one('range') if not et.search_one('range') \
                                               is None else False
@@ -1012,14 +1070,16 @@ def build_elemtype(ctx, et, prefix=False):
 
   if length_stmt:
     if "|" in length_stmt.arg:
-      restrictions['length'] = [i.replace(' ', '') for i in length_stmt.arg.split("|")]
+      restrictions['length'] = [i.replace(' ', '') for i in
+                                  length_stmt.arg.split("|")]
     else:
       restrictions['length'] = [length_stmt.arg]
 
   if range_stmt:
     # Complex ranges are separated by pipes
     if "|" in range_stmt.arg:
-      restrictions['range'] = [i.replace(' ', '') for i in range_stmt.arg.split("|")]
+      restrictions['range'] = [i.replace(' ', '') for i in
+                                  range_stmt.arg.split("|")]
     else:
       restrictions['range'] = [range_stmt.arg]
 
@@ -1029,23 +1089,23 @@ def build_elemtype(ctx, et, prefix=False):
     if 'length' in restrictions or 'pattern' in restrictions:
       cls = "restricted-%s" % (et.arg)
       elemtype = {
-                  "native_type": \
-                    """RestrictedClassType(base_type=%s, restriction_dict=%s)"""
-                      % (class_map[et.arg]["native_type"], repr(restrictions)),
-                  "restriction_dict": restrictions,
-                  "parent_type": et.arg,
-                  "base_type": False,
-                  }
+          "native_type":
+              """RestrictedClassType(base_type=%s, restriction_dict=%s)"""
+              % (class_map[et.arg]["native_type"], repr(restrictions)),
+          "restriction_dict": restrictions,
+          "parent_type": et.arg,
+          "base_type": False,
+      }
     elif 'range' in restrictions:
       cls = "restricted-%s" % et.arg
       elemtype = {
-                  "native_type": \
-                    """RestrictedClassType(base_type=%s, restriction_dict=%s)"""
-                      % (class_map[et.arg]["native_type"], repr(restrictions)),
-                  "restriction_dict": restrictions,
-                  "parent_type": et.arg,
-                  "base_type": False,
-                 }
+          "native_type":
+              """RestrictedClassType(base_type=%s, restriction_dict=%s)"""
+              % (class_map[et.arg]["native_type"], repr(restrictions)),
+          "restriction_dict": restrictions,
+          "parent_type": et.arg,
+          "base_type": False,
+      }
 
   # Handle all other types of leaves that are not restricted classes.
   if cls is None:
@@ -1061,23 +1121,23 @@ def build_elemtype(ctx, et, prefix=False):
           enumeration_dict[unicode(enum.arg)]["value"] = int(val.arg)
       elemtype = {"native_type": """RestrictedClassType(base_type=unicode, \
                                     restriction_type="dict_key", \
-                                    restriction_arg=%s,)""" % \
-                                    (enumeration_dict), \
-                  "restriction_argument": enumeration_dict, \
-                  "restriction_type": "dict_key", \
-                  "parent_type": "string", \
-                  "base_type": False,}
+                                    restriction_arg=%s,)""" %
+                                    (enumeration_dict),
+                  "restriction_argument": enumeration_dict,
+                  "restriction_type": "dict_key",
+                  "parent_type": "string",
+                  "base_type": False}
     # Map decimal64 to a RestrictedPrecisionDecimalType - this is there to
     # ensure that the fraction-digits argument can be implemented. Note that
     # fraction-digits is a mandatory argument.
     elif et.arg == "decimal64":
       fd_stmt = et.search_one('fraction-digits')
-      if not fd_stmt is None:
+      if fd_stmt is not None:
         cls = "restricted-decimal64"
-        elemtype = {"native_type": \
-                      """RestrictedPrecisionDecimalType(precision=%s)""" % \
-                      fd_stmt.arg, "base_type": False, \
-                      "parent_type": "decimal64",}
+        elemtype = {"native_type":
+                      """RestrictedPrecisionDecimalType(precision=%s)""" %
+                      fd_stmt.arg, "base_type": False,
+                      "parent_type": "decimal64"}
       else:
         elemtype = class_map[et.arg]
     # Handle unions - build a list of the supported types that are under the
@@ -1089,14 +1149,15 @@ def build_elemtype(ctx, et, prefix=False):
         elemtype_s[1]["yang_type"] = uniontype.arg
         elemtype.append(elemtype_s)
       cls = "union"
-    # Map leafrefs to a ReferenceType, handling the referenced path, and whether
-    # require-instance is set. When xpathhelper is not specified, then no such
-    # mapping is done - at this point, we solely map to a string.
+    # Map leafrefs to a ReferenceType, handling the referenced path, and
+    # whether require-instance is set. When xpathhelper is not specified, then
+    # no such mapping is done - at this point, we solely map to a string.
     elif et.arg == "leafref":
       path_stmt = et.search_one('path')
       if path_stmt is None:
         raise ValueError("leafref specified with no path statement")
-      require_instance = class_bool_map[et.search_one('require-instance').arg] \
+      require_instance = \
+                  class_bool_map[et.search_one('require-instance').arg] \
                           if et.search_one('require-instance') \
                             is not None else False
       if ctx.opts.use_xpathhelper:
@@ -1108,10 +1169,10 @@ def build_elemtype(ctx, et, prefix=False):
         cls = "leafref"
       else:
         elemtype = {
-                    "native_type": "unicode",
-                    "parent_type": "string",
-                    "base_type": False,
-                   }
+            "native_type": "unicode",
+            "parent_type": "string",
+            "base_type": False,
+        }
     # Handle identityrefs, but check whether there is a valid base where this
     # has been specified.
     elif et.arg == "identityref":
@@ -1143,7 +1204,7 @@ def build_elemtype(ctx, et, prefix=False):
             passed = True
           except:
             pass
-        if passed == False:
+        if passed is False:
           sys.stderr.write("FATAL: unmapped type (%s)\n" % (et.arg))
           if DEBUG:
             pp.pprint(class_map.keys())
@@ -1156,7 +1217,8 @@ def build_elemtype(ctx, et, prefix=False):
       # this is used to propagate the fact that in some cases the
       # native type needs to be dynamically built (e.g., leafref)
       cls = elemtype["class_override"]
-  return (cls,elemtype)
+  return (cls, elemtype)
+
 
 def find_absolute_default_type(default_type, default_value, elemname):
   if not isinstance(default_type, list):
@@ -1174,7 +1236,6 @@ def find_absolute_default_type(default_type, default_value, elemname):
     except ValueError:
       pass
   return find_absolute_default_type(default_type, default_value, elemname)
-
 
 
 def get_element(ctx, fd, element, module, parent, path,
@@ -1207,25 +1268,26 @@ def get_element(ctx, fd, element, module, parent, path,
     if element.keyword in ["choice"]:
       path_parts = path.split("/")
       npath = ""
-      for i in range(0,len(path_parts)-1):
+      for i in range(0, len(path_parts) - 1):
         npath += "%s/" % path_parts[i]
       npath.rstrip("/")
     else:
-      npath=path
+      npath = path
 
     # Create an element for a container.
     if element.i_children:
       chs = element.i_children
-      get_children(ctx, fd, chs, module, element, npath, parent_cfg=parent_cfg,\
+      get_children(ctx, fd, chs, module, element, npath, parent_cfg=parent_cfg,
                    choice=choice)
 
-      elemdict = {"name": safe_name(element.arg), "origtype": element.keyword,
-                          "class": element.keyword,
-                          "path": safe_name(npath), "config": True,
-                          "description": elemdescr,
-                          "yang_name": element.arg,
-                          "choice": choice,
-                 }
+      elemdict = {
+          "name": safe_name(element.arg), "origtype": element.keyword,
+          "class": element.keyword,
+          "path": safe_name(npath), "config": True,
+          "description": elemdescr,
+          "yang_name": element.arg,
+          "choice": choice,
+      }
       # Handle the different cases of class name, this depends on whether we
       # were asked to split the bindings into a directory structure or not.
       if ctx.opts.split_class_dir:
@@ -1248,7 +1310,7 @@ def get_element(ctx, fd, element, module, parent, path,
       # ordered.
       if element.keyword == "list":
         elemdict["key"] = safe_name(element.search_one("key").arg) \
-                            if element.search_one("key") is not None else False
+            if element.search_one("key") is not None else False
         user_ordered = element.search_one('ordered-by')
         elemdict["user_ordered"] = True if user_ordered is not None \
           and user_ordered.arg.upper() == "USER" else False
@@ -1259,7 +1321,8 @@ def get_element(ctx, fd, element, module, parent, path,
   if not has_children:
     if element.keyword in ["leaf-list"]:
       create_list = True
-    cls,elemtype = copy.deepcopy(build_elemtype(ctx, element.search_one('type')))
+    cls, elemtype = copy.deepcopy(build_elemtype(ctx,
+                        element.search_one('type')))
 
     # Determine what the default for the leaf should be where there are
     # multiple available.
@@ -1274,7 +1337,7 @@ def get_element(ctx, fd, element, module, parent, path,
     elemdefault = element.search_one('default')
     default_type = False
     quote_arg = False
-    if not elemdefault is None:
+    if elemdefault is not None:
       elemdefault = elemdefault.arg
       default_type = elemtype
     if isinstance(elemtype, list):
@@ -1284,8 +1347,8 @@ def get_element(ctx, fd, element, module, parent, path,
         if "default" in i[1]:
           elemdefault = i[1]["default"]
           default_type = i[1]
-          #default_type = i[1]
-          #mapped_elemtype = i[1]
+          # default_type = i[1]
+          # mapped_elemtype = i[1]
     elif "default" in elemtype:
       # if the actual type defines the default, then we need to maintain
       # this
@@ -1305,12 +1368,12 @@ def get_element(ctx, fd, element, module, parent, path,
             if isinstance(i[1]["parent_type"], list):
               to_visit = [j for j in i[1]["parent_type"]]
             else:
-              to_visit = [i[1]["parent_type"],]
+              to_visit = [i[1]["parent_type"]]
       elif "parent_type" in elemtype:
         if isinstance(elemtype["parent_type"], list):
           to_visit = [i for i in elemtype["parent_type"]]
         else:
-          to_visit = [elemtype["parent_type"],]
+          to_visit = [elemtype["parent_type"]]
 
         checked = list()
         while to_visit:
@@ -1341,18 +1404,19 @@ def get_element(ctx, fd, element, module, parent, path,
       # a single option for the type. check the default
       # against each option, to get a to a single default_type
       if isinstance(default_type, list):
-        default_type = find_absolute_default_type(default_type, elemdefault, element.arg)
+        default_type = find_absolute_default_type(default_type, elemdefault,
+                          element.arg)
 
       if not default_type["base_type"]:
         if "parent_type" in default_type:
           if isinstance(default_type["parent_type"], list):
             to_visit = [i for i in default_type["parent_type"]]
           else:
-            to_visit = [default_type["parent_type"],]
+            to_visit = [default_type["parent_type"]]
         checked = list()
         while to_visit:
-          check = to_visit.pop(0) # remove from the top of stack - depth first
-          if not check in checked:
+          check = to_visit.pop(0)  # remove from the top of stack - depth first
+          if check not in checked:
             checked.append(check)
             if "parent_type" in tmp_class_map[check]:
               if isinstance(tmp_class_map[check]["parent_type"], list):
@@ -1367,7 +1431,7 @@ def get_element(ctx, fd, element, module, parent, path,
     # correct value to set.
     if default_type:
       quote_arg = default_type["quote_arg"] if "quote_arg" in \
-                    default_type else False
+          default_type else False
       default_type = default_type["native_type"]
 
     elemconfig = class_bool_map[element.search_one('config').arg] if \
@@ -1403,11 +1467,11 @@ def get_element(ctx, fd, element, module, parent, path,
       else:
         cls = "leafref-list"
         allowed_types = {
-                          "native_type": elemtype["native_type"],
-                          "referenced_path": elemtype["referenced_path"],
-                          "require_instance": elemtype["require_instance"],
-                        }
-      elemntype = {"class": cls, "native_type": ("TypedListType", \
+            "native_type": elemtype["native_type"],
+            "referenced_path": elemtype["referenced_path"],
+            "require_instance": elemtype["require_instance"],
+        }
+      elemntype = {"class": cls, "native_type": ("TypedListType",
                   allowed_types)}
 
     else:
@@ -1415,17 +1479,18 @@ def get_element(ctx, fd, element, module, parent, path,
         elemtype = {"class": cls, "native_type": ("UnionType", elemtype)}
       elemntype = elemtype["native_type"]
 
-    # Build the dictionary for the element with the relevant meta-data specified
-    # within it.
-    elemdict = {"name": elemname, "type": elemntype,
-                        "origtype": element.search_one('type').arg, "path": \
-                        safe_name(path),
-                        "class": cls, "default": elemdefault, \
-                        "config": elemconfig, "defaulttype": default_type, \
-                        "quote_arg": quote_arg, \
-                        "description": elemdescr, "yang_name": element.arg,
-                        "choice": choice,
-               }
+    # Build the dictionary for the element with the relevant meta-data
+    # specified within it.
+    elemdict = {
+        "name": elemname, "type": elemntype,
+        "origtype": element.search_one('type').arg, "path":
+        safe_name(path),
+        "class": cls, "default": elemdefault,
+        "config": elemconfig, "defaulttype": default_type,
+        "quote_arg": quote_arg,
+        "description": elemdescr, "yang_name": element.arg,
+        "choice": choice,
+    }
     if cls == "leafref":
       elemdict["referenced_path"] = elemtype["referenced_path"]
       elemdict["require_instance"] = elemtype["require_instance"]
@@ -1433,7 +1498,8 @@ def get_element(ctx, fd, element, module, parent, path,
     # In cases where there there are a set of interesting extensions specified
     # then build a dictionary of these extension values to provide with the
     # specific leaf for this element.
-    if element.substmts is not None and ctx.opts.pybind_interested_exts is not None:
+    if element.substmts is not None and \
+          ctx.opts.pybind_interested_exts is not None:
       extensions = {}
       for ext in element.substmts:
         if ext.keyword[0] in ctx.opts.pybind_interested_exts:
@@ -1445,4 +1511,3 @@ def get_element(ctx, fd, element, module, parent, path,
 
     this_object.append(elemdict)
   return this_object
-

--- a/tests/binary/run.py
+++ b/tests/binary/run.py
@@ -1,11 +1,13 @@
 #!/usr/bin/env python
 
-import os, sys, getopt
+import os
+import sys
+import getopt
 
-TESTNAME="binary"
+TESTNAME = "binary"
+
 
 # generate bindings in this folder
-
 def main():
   try:
     opts, args = getopt.getopt(sys.argv[1:], "k", ["keepfiles"])
@@ -18,25 +20,28 @@ def main():
     if o in ["-k", "--keepfiles"]:
       k = True
 
-  pyangpath = os.environ.get('PYANGPATH') if os.environ.get('PYANGPATH') is not None else False
-  pyangbindpath = os.environ.get('PYANGBINDPATH') if os.environ.get('PYANGBINDPATH') is not None else False
-  assert not pyangpath == False, "could not find path to pyang"
-  assert not pyangbindpath == False, "could not resolve pyangbind directory"
+  pyangpath = os.environ.get('PYANGPATH') if \
+                os.environ.get('PYANGPATH') is not None else False
+  pyangbindpath = os.environ.get('PYANGBINDPATH') if \
+                os.environ.get('PYANGBINDPATH') is not None else False
+  assert pyangpath is not False, "could not find path to pyang"
+  assert pyangbindpath is not False, "could not resolve pyangbind directory"
 
   this_dir = os.path.dirname(os.path.realpath(__file__))
-  os.system("%s --plugindir %s -f pybind -o %s/bindings.py %s/%s.yang" % (pyangpath, pyangbindpath, this_dir, this_dir, TESTNAME))
+  os.system("%s --plugindir %s -f pybind -o %s/bindings.py %s/%s.yang" %
+              (pyangpath, pyangbindpath, this_dir, this_dir, TESTNAME))
 
   from bindings import binary as b
   from bitarray import bitarray
   t = b()
 
   for i in ["b1", "b2", "b3"]:
-    assert hasattr(t.container, i), "element did not exist in container (%s)" \
-      % i
+    assert hasattr(t.container, i), \
+        "element did not exist in container (%s)" % i
 
-  for value in [("01110", True, [False, True, True, True, False],), \
-                ({"42": 42}, True, [True]), \
-               ]:
+  for value in [
+      ("01110", True, [False, True, True, True, False],),
+          ({"42": 42}, True, [True])]:
     passed = True
     try:
       t.container.b1 = value[0]
@@ -48,7 +53,6 @@ def main():
     "Default for leaf b2 was not set correctly (%s != %s)" \
        % (t.container.b2._default, bitarray("0100"))
 
-
   assert t.container.b2 == bitarray(), \
     "Value of bitarray was not null when checking b2 (%s != %s)" \
         % (t.container.b2, bitarray())
@@ -59,10 +63,12 @@ def main():
 
   t.container.b2 = bitarray("010")
   assert t.container.b2 == bitarray('010'), \
-    "Bitarray not successfuly set (%s != %s)" % (t.container.b2, bitarray('010'))
+    "Bitarray not successfuly set (%s != %s)" % \
+        (t.container.b2, bitarray('010'))
 
   assert t.container.b2._changed() == True, \
-    "Bitarray value not flagged as changed (%s != %s)" % (t.container.b2._changed(), True)
+    "Bitarray value not flagged as changed (%s != %s)" % \
+        (t.container.b2._changed(), True)
 
   for v in [("0", False), ("01", True), ("010", False)]:
     try:
@@ -70,8 +76,9 @@ def main():
       passed = True
     except ValueError:
       passed = False
-    assert passed == v[1], "limited length binary incorrectly set to %s (%s != %s)" \
-      % (v[0], v[1], passed)
+    assert passed == v[1], \
+        "limited length binary incorrectly set to %s (%s != %s)" \
+          % (v[0], v[1], passed)
 
   for v in [("0", False), ("01", True), ("1111", True), ("10000001", False)]:
     try:
@@ -79,18 +86,20 @@ def main():
       passed = True
     except ValueError:
       passed = False
-    assert passed == v[1], "limited length binary with range incorrectly set to %s (%s != %s)" \
-      % (v[0], v[1], passed)
+    assert passed == v[1], "limited length binary with range incorrectly " + \
+      "set to %s (%s != %s)" % (v[0], v[1], passed)
 
-  for v in [("0", False), ("01", True), ("010", True), ("01000", False), ("100000", True), ("10101010101010101010101010101", True), \
-            ("101010101010101010101010101010101010101010101010101010101010101010101010", False)]:
+  for v in [("0", False), ("01", True), ("010", True), ("01000", False),
+      ("100000", True), ("10101010101010101010101010101", True),
+          ("10101010101010101010101010101010101010101010101010101010" +
+              "1010101010101010", False)]:
     try:
       t.container.b5 = v[0]
       passed = True
     except:
       passed = False
-    assert passed == v[1], "limited length binary with complex length argument incorrecty set to %s (%s != %s)" \
-        % (v[0], v[1], passed)
+    assert passed == v[1], "limited length binary with complex length " + \
+        "argument incorrectly set to %s (%s != %s)" % (v[0], v[1], passed)
 
   if not k:
     os.system("/bin/rm %s/bindings.py" % this_dir)

--- a/tests/boolean-empty/run.py
+++ b/tests/boolean-empty/run.py
@@ -1,11 +1,14 @@
 #!/usr/bin/env python
 
-import os, sys, getopt
 
-TESTNAME="boolean-empty"
+import os
+import sys
+import getopt
+
+TESTNAME = "boolean-empty"
+
 
 # generate bindings in this folder
-
 def main():
   try:
     opts, args = getopt.getopt(sys.argv[1:], "k", ["keepfiles"])
@@ -18,13 +21,16 @@ def main():
     if o in ["-k", "--keepfiles"]:
       k = True
 
-  pyangpath = os.environ.get('PYANGPATH') if os.environ.get('PYANGPATH') is not None else False
-  pyangbindpath = os.environ.get('PYANGBINDPATH') if os.environ.get('PYANGBINDPATH') is not None else False
-  assert not pyangpath == False, "could not find path to pyang"
-  assert not pyangbindpath == False, "could not resolve pyangbind directory"
+  pyangpath = os.environ.get('PYANGPATH') if \
+                os.environ.get('PYANGPATH') is not None else False
+  pyangbindpath = os.environ.get('PYANGBINDPATH') if \
+                os.environ.get('PYANGBINDPATH') is not None else False
+  assert pyangpath is not False, "could not find path to pyang"
+  assert pyangbindpath is not False, "could not resolve pyangbind directory"
 
   this_dir = os.path.dirname(os.path.realpath(__file__))
-  os.system("%s --plugindir %s -f pybind -o %s/bindings.py %s/%s.yang" % (pyangpath, pyangbindpath, this_dir, this_dir, TESTNAME))
+  os.system("%s --plugindir %s -f pybind -o %s/bindings.py %s/%s.yang" %
+              (pyangpath, pyangbindpath, this_dir, this_dir, TESTNAME))
 
   from bindings import boolean_empty as b
 
@@ -32,41 +38,43 @@ def main():
 
   for i in ["b1", "b2", "e1"]:
     assert hasattr(t.container, i), "element did not exist in container (%s)" \
-      % i
+        % i
 
-  for value in [(0, False), ("0", False), (False, False), ("false", False), ("False", False), \
-                (1, True), ("1", True), (True,True), ("true", True), ("True", True)]:
+  for value in [(0, False), ("0", False), (False, False), ("false", False),
+                ("False", False), (1, True), ("1", True), (True, True),
+                ("true", True), ("True", True)]:
     passed = True
     try:
       t.container.b1 = value[0]
     except:
       passed = False
 
-    assert passed == True, "value of b1 was not correctly set to %s" % value
-    assert t.container.b1 == value[1], "value of b1 was not correctly set when compared (%s - set to %s)" % \
-      (t.container.b1, value)
+    assert passed is True, "value of b1 was not correctly set to %s" % value
+    assert t.container.b1 == value[1], "value of b1 was not correctly set " + \
+        "when compared (%s - set to %s)" % (t.container.b1, value)
 
-  for value in [(0, False), ("0", False), (False, False), ("false", False), ("False", False), \
-                (1, True), ("1", True), (True,True), ("true", True), ("True", True)]:
+  for value in [(0, False), ("0", False), (False, False), ("false", False),
+                ("False", False), (1, True), ("1", True), (True, True),
+                ("true", True), ("True", True)]:
     passed = True
     try:
       t.container.e1 = value[0]
     except:
       passed = False
 
-    assert passed == True, "value of e1 was not correctly set to %s" % value
-    assert t.container.e1 == value[1], "value of e1 was not correctly set when compared (%s - set to %s)" % \
-      (t.container.e1, value)
+    assert passed is True, "value of e1 was not correctly set to %s" % value
+    assert t.container.e1 == value[1], "value of e1 was not correctly set " + \
+        "when compared (%s - set to %s)" % (t.container.e1, value)
 
-  assert t.container.b2._default == False, "value default was not correctly set (%s)" % \
-    t.container.b2._default
+  assert t.container.b2._default is False, "value default was not " + \
+      "correctly set (%s)" % t.container.b2._default
 
-  assert t.container.b2._changed() == False, "value was marked as changed incorrectly (%s)" %\
-    t.container.b2._changed()
+  assert t.container.b2._changed() == False, "value was marked as changed " + \
+      "incorrectly (%s)" % t.container.b2._changed()
 
   t.container.b2 = True
-  assert t.container.b2._changed() == True, "value was not marked as changed when it was (%s)" % \
-    t.container.b2._changed()
+  assert t.container.b2._changed() == True, "value was not marked as " + \
+      "when it was (%s)" % t.container.b2._changed()
 
   t.container.b2 = False
   assert t.get() == {'container': {'e1': True, 'b1': True, 'b2': False}}, \

--- a/tests/choice/run.py
+++ b/tests/choice/run.py
@@ -1,11 +1,13 @@
 #!/usr/bin/env python
 
-import os, sys, getopt
+import os
+import sys
+import getopt
 
-TESTNAME="choice"
+TESTNAME = "choice"
+
 
 # generate bindings in this folder
-
 def main():
   try:
     opts, args = getopt.getopt(sys.argv[1:], "k", ["keepfiles"])
@@ -18,33 +20,50 @@ def main():
     if o in ["-k", "--keepfiles"]:
       keepfiles = True
 
-  pyangpath = os.environ.get('PYANGPATH') if os.environ.get('PYANGPATH') is not None else False
-  pyangbindpath = os.environ.get('PYANGBINDPATH') if os.environ.get('PYANGBINDPATH') is not None else False
-  assert not pyangpath == False, "could not find path to pyang"
-  assert not pyangbindpath == False, "could not resolve pyangbind directory"
+  pyangpath = os.environ.get('PYANGPATH') if \
+                os.environ.get('PYANGPATH') is not None else False
+  pyangbindpath = os.environ.get('PYANGBINDPATH') if \
+                os.environ.get('PYANGBINDPATH') is not None else False
+  assert pyangpath is not False, "could not find path to pyang"
+  assert pyangbindpath is not False, "could not resolve pyangbind directory"
 
   this_dir = os.path.dirname(os.path.realpath(__file__))
-  os.system("%s --plugindir %s -f pybind -o %s/bindings.py %s/%s.yang" % (pyangpath, pyangbindpath, this_dir, this_dir, TESTNAME))
+  os.system("%s --plugindir %s -f pybind -o %s/bindings.py %s/%s.yang" %
+              (pyangpath, pyangbindpath, this_dir, this_dir, TESTNAME))
 
   from bindings import choice
   t = choice()
 
   assert hasattr(t, "container"), "object does not have container"
   for i in ["case_one_container", "case_two_container"]:
-    assert hasattr(t.container,i), "object does not have choice container, %s" % i
+    assert hasattr(t.container, i), "object does not have choice container" + \
+        ", %s" % i
   for i in ["choice_one", "choice_two", "case_one", "case_two"]:
-    assert not hasattr(t.container,i), "object has an erroneous choice option, %s" % i
+    assert not hasattr(t.container, i), \
+        "object has an erroneous choice option, %s" % i
 
-  assert t.container.case_one_container.case_one_leaf == 0, "object does not have the correct value for case_one_leaf, %s" % t.container.case_one_container.case_one_leaf
-  assert t.container.case_two_container.case_two_leaf == 0, "object does not have the correct value for case_two_leaf, %s" % t.container.case_two_container.case_two_leaf
+  assert t.container.case_one_container.case_one_leaf == 0, \
+      "object does not have the correct value for case_one_leaf, %s" % \
+          t.container.case_one_container.case_one_leaf
+  assert t.container.case_two_container.case_two_leaf == 0, \
+      "object does not have the correct value for case_two_leaf, %s" % \
+          t.container.case_two_container.case_two_leaf
 
   t.container.case_one_container.case_one_leaf = 42
-  assert t.container.case_one_container.case_one_leaf == 42, "object did not specify a value within the choice correctly, %s" % t.container.case_one_container.case_one_leaf
-  assert t.container.case_two_container.case_two_leaf == 0, "object erroneously set another value wtihin the choice, %s" % t.container.case_two_container.case_two_leaf
+  assert t.container.case_one_container.case_one_leaf == 42, \
+      "object did not specify a value within the choice correctly, %s" \
+          % t.container.case_one_container.case_one_leaf
+  assert t.container.case_two_container.case_two_leaf == 0, \
+      "object erroneously set another value wtihin the choice, %s" \
+        % t.container.case_two_container.case_two_leaf
 
   t.container.case_two_container.case_two_leaf = 42
-  assert t.container.case_two_container.case_two_leaf == 42, "object did not allow the other half of the choice to be specified, %s" % t.container.case_two_container.case_two_leaf
-  assert t.container.case_one_container.case_one_leaf == 0, "object did not reset the value of the case-one side of the choice, %s" % t.container.case_one_container.case_one_leaf
+  assert t.container.case_two_container.case_two_leaf == 42, \
+      "object did not allow the other half of the choice to be specified, %s" \
+        % t.container.case_two_container.case_two_leaf
+  assert t.container.case_one_container.case_one_leaf == 0, \
+    "object did not reset the value of the case-one side of the choice, %s" \
+       % t.container.case_one_container.case_one_leaf
 
   if not keepfiles:
     os.system("/bin/rm %s/bindings.py" % this_dir)

--- a/tests/config-false/run.py
+++ b/tests/config-false/run.py
@@ -1,11 +1,13 @@
 #!/usr/bin/env python
 
-import os, sys, getopt
+import os
+import sys
+import getopt
 
-TESTNAME="config-false"
+TESTNAME = "config-false"
+
 
 # generate bindings in this folder
-
 def main():
   try:
     opts, args = getopt.getopt(sys.argv[1:], "k", ["keepfiles"])
@@ -18,32 +20,35 @@ def main():
     if o in ["-k", "--keepfiles"]:
       keepfiles = True
 
-  pyangpath = os.environ.get('PYANGPATH') if os.environ.get('PYANGPATH') is not None else False
-  pyangbindpath = os.environ.get('PYANGBINDPATH') if os.environ.get('PYANGBINDPATH') is not None else False
-  assert not pyangpath == False, "could not find path to pyang"
-  assert not pyangbindpath == False, "could not resolve pyangbind directory"
+  pyangpath = os.environ.get('PYANGPATH') if \
+                os.environ.get('PYANGPATH') is not None else False
+  pyangbindpath = os.environ.get('PYANGBINDPATH') if \
+                os.environ.get('PYANGBINDPATH') is not None else False
+  assert pyangpath is not False, "could not find path to pyang"
+  assert pyangbindpath is not False, "could not resolve pyangbind directory"
 
   this_dir = os.path.dirname(os.path.realpath(__file__))
-  os.system("%s --plugindir %s -f pybind -o %s/bindings.py %s/%s.yang" % (pyangpath, pyangbindpath, this_dir, this_dir, TESTNAME))
+  os.system("%s --plugindir %s -f pybind -o %s/bindings.py %s/%s.yang" %
+              (pyangpath, pyangbindpath, this_dir, this_dir, TESTNAME))
 
   from bindings import config_false
 
   test_instance = config_false()
 
   structure_dict = {
-                      "container": {
-                                      "subone": {
-                                                  "a_leaf": True,
-                                                  "d_leaf": False,
-                                                },
-                                      "subtwo": {
-                                                  "b_leaf": False,
-                                                  "subsubtwo": {
-                                                                  "c_leaf": False,
-                                                                }
-                                                }
-                                    }
-                    }
+      "container": {
+          "subone": {
+              "a_leaf": True,
+              "d_leaf": False,
+          },
+          "subtwo": {
+              "b_leaf": False,
+              "subsubtwo": {
+                  "c_leaf": False,
+              }
+          }
+      }
+  }
 
   for i in structure_dict.keys():
     assert hasattr(test_instance, i), "top level %s does not exist" % i
@@ -68,7 +73,8 @@ def main():
   except AttributeError:
     passed = False
 
-  assert passed == structure_dict["container"]["subone"]["a_leaf"], "setting a_leaf did not result in expected outcome (%s != %s)" \
+  assert passed == structure_dict["container"]["subone"]["a_leaf"], \
+      "setting a_leaf did not result in expected outcome (%s != %s)" \
         % (structure_dict["container"]["subone"]["a_leaf"], passed)
 
   passed = True
@@ -77,7 +83,8 @@ def main():
   except AttributeError:
     passed = False
 
-  assert passed == structure_dict["container"]["subone"]["d_leaf"], "setting d_leaf did not result in expected outcome (%s != %s)" \
+  assert passed == structure_dict["container"]["subone"]["d_leaf"], \
+      "setting d_leaf did not result in expected outcome (%s != %s)" \
         % (structure_dict["container"]["subone"]["d_leaf"], passed)
 
   passed = True
@@ -86,7 +93,8 @@ def main():
   except AttributeError:
     passed = False
 
-  assert passed == structure_dict["container"]["subtwo"]["b_leaf"], "setting b_leaf did not result in expected outcome (%s != %s)" \
+  assert passed == structure_dict["container"]["subtwo"]["b_leaf"], \
+      "setting b_leaf did not result in expected outcome (%s != %s)" \
         % (structure_dict["container"]["subtwo"]["b_leaf"], passed)
 
   passed = True
@@ -95,8 +103,11 @@ def main():
   except AttributeError:
     passed = False
 
-  assert passed == structure_dict["container"]["subtwo"]["subsubtwo"]["c_leaf"], "setting c_leaf did not result in expected outcome (%s != %s)" \
-        % (structure_dict["container"]["subtwo"]["subsubtwo"]["c_leaf"], passed)
+  assert passed == \
+    structure_dict["container"]["subtwo"]["subsubtwo"]["c_leaf"], \
+      "setting c_leaf did not result in expected outcome (%s != %s)" \
+        % (structure_dict["container"]["subtwo"]["subsubtwo"]["c_leaf"],
+              passed)
 
   if not keepfiles:
     os.system("/bin/rm %s/bindings.py" % this_dir)

--- a/tests/decimal64/run.py
+++ b/tests/decimal64/run.py
@@ -1,11 +1,13 @@
 #!/usr/bin/env python
 
-import os, sys, getopt
+import os
+import sys
+import getopt
 
-TESTNAME="decimal"
+TESTNAME = "decimal"
+
 
 # generate bindings in this folder
-
 def main():
   try:
     opts, args = getopt.getopt(sys.argv[1:], "k", ["keepfiles"])
@@ -18,13 +20,16 @@ def main():
     if o in ["-k", "--keepfiles"]:
       k = True
 
-  pyangpath = os.environ.get('PYANGPATH') if os.environ.get('PYANGPATH') is not None else False
-  pyangbindpath = os.environ.get('PYANGBINDPATH') if os.environ.get('PYANGBINDPATH') is not None else False
-  assert not pyangpath == False, "could not find path to pyang"
-  assert not pyangbindpath == False, "could not resolve pyangbind directory"
+  pyangpath = os.environ.get('PYANGPATH') if \
+                os.environ.get('PYANGPATH') is not None else False
+  pyangbindpath = os.environ.get('PYANGBINDPATH') if \
+                os.environ.get('PYANGBINDPATH') is not None else False
+  assert pyangpath is not False, "could not find path to pyang"
+  assert pyangbindpath is not False, "could not resolve pyangbind directory"
 
   this_dir = os.path.dirname(os.path.realpath(__file__))
-  os.system("%s --plugindir %s -f pybind -o %s/bindings.py %s/%s.yang" % (pyangpath, pyangbindpath, this_dir, this_dir, TESTNAME))
+  os.system("%s --plugindir %s -f pybind -o %s/bindings.py %s/%s.yang" %
+              (pyangpath, pyangbindpath, this_dir, this_dir, TESTNAME))
 
   from bindings import decimal_ as d
   from decimal import Decimal
@@ -35,23 +40,31 @@ def main():
     assert hasattr(q.container, i), "container missing attribute - %s" % i
 
   q.container.d1 = 42.0
-  assert len(str(q.container.d1).split(".")[1]) == 2, "precision for d1 was incorrect %s" % q.container.d1
+  assert len(str(q.container.d1).split(".")[1]) == 2, \
+      "precision for d1 was incorrect %s" % q.container.d1
   q.container.d2 = 42.0009
-  assert q.container.d2 == Decimal("42.001"), "precision did not result in correct rounding (%s)" \
+  assert q.container.d2 == Decimal("42.001"), \
+      "precision did not result in correct rounding (%s)" \
           % q.container.d2
-  assert q.container.d2._default == Decimal("42.000"), "default was set wrong for d2 (%s)" \
+  assert q.container.d2._default == Decimal("42.000"), \
+      "default was set wrong for d2 (%s)" \
           % q.container.d2._default
-  assert q.container.d3._default == Decimal("1"), "default was set wrong for d3 (%s)" \
+  assert q.container.d3._default == Decimal("1"), \
+      "default was set wrong for d3 (%s)" \
           % q.container.d3._default
 
-  for i in [(-452.6729, False), (-444.44, True), (-443.22, False), (-330, True), (-222.21, False), (111.2, False), (111.1, True), (446.56, True), (555.55559282, False)]:
+  for i in [(-452.6729, False), (-444.44, True), (-443.22, False),
+            (-330, True), (-222.21, False), (111.2, False), (111.1, True),
+            (446.56, True), (555.55559282, False)]:
     passed = False
     try:
       q.container.dec64LeafWithRange = i[0]
       passed = True
     except ValueError, m:
       pass
-    assert passed == i[1], "decimal64 leaf with range was not correctly set (%f -> %s != %s)" % (i[0], passed, i[1])
+    assert passed == i[1], \
+        "decimal64 leaf with range was not correctly set (%f -> %s != %s)" \
+            % (i[0], passed, i[1])
 
   if not k:
     os.system("/bin/rm %s/bindings.py" % this_dir)

--- a/tests/enumeration/run.py
+++ b/tests/enumeration/run.py
@@ -1,11 +1,13 @@
 #!/usr/bin/env python
 
-import os, sys, getopt
+import os
+import sys
+import getopt
 
-TESTNAME="enumeration"
+TESTNAME = "enumeration"
+
 
 # generate bindings in this folder
-
 def main():
   try:
     opts, args = getopt.getopt(sys.argv[1:], "k", ["keepfiles"])
@@ -18,38 +20,46 @@ def main():
     if o in ["-k", "--keepfiles"]:
       k = True
 
-  pyangpath = os.environ.get('PYANGPATH') if os.environ.get('PYANGPATH') is not None else False
-  pyangbindpath = os.environ.get('PYANGBINDPATH') if os.environ.get('PYANGBINDPATH') is not None else False
-  assert not pyangpath == False, "could not find path to pyang"
-  assert not pyangbindpath == False, "could not resolve pyangbind directory"
+  pyangpath = os.environ.get('PYANGPATH') if \
+                os.environ.get('PYANGPATH') is not None else False
+  pyangbindpath = os.environ.get('PYANGBINDPATH') if \
+                os.environ.get('PYANGBINDPATH') is not None else False
+  assert pyangpath is not False, "could not find path to pyang"
+  assert pyangbindpath is not False, "could not resolve pyangbind directory"
 
   this_dir = os.path.dirname(os.path.realpath(__file__))
-  os.system("%s --plugindir %s -f pybind -o %s/bindings.py %s/%s.yang" % (pyangpath, pyangbindpath, this_dir, this_dir, TESTNAME))
+  os.system("%s --plugindir %s -f pybind -o %s/bindings.py %s/%s.yang" %
+              (pyangpath, pyangbindpath, this_dir, this_dir, TESTNAME))
 
   from bindings import enumeration
   t = enumeration()
 
   for e in ["e", "f"]:
-    assert hasattr(t.container, e), "container does not contain enumeration %s" % e
+    assert hasattr(t.container, e), \
+        "container does not contain enumeration %s" % e
 
   t.container.e = "one"
-  assert t.container.e == "one", "enumeration value was not correctly set (%s)" % \
-    t.container.e
+  assert t.container.e == "one", \
+      "enumeration value was not correctly set (%s)" % \
+          t.container.e
 
   catch = False
   try:
     t.container.e = "twentyseven"
   except:
     catch = True
-  assert catch == True, "erroneous value was not caught by restriction handler (%s)" % \
-    t.container.e
+  assert catch is True, \
+      "erroneous value was not caught by restriction handler (%s)" % \
+        t.container.e
 
-  assert t.container.f._default == "c", "erroneous default value for 'f' (%s)" % \
-    t.container.f._default
+  assert t.container.f._default == "c", \
+      "erroneous default value for 'f' (%s)" % \
+          t.container.f._default
 
   t.container.e = "two"
-  assert t.container.e.getValue(mapped=True) == 42, "erroneously statically defined value returned (%s)" % \
-    t.container.e.getValue(mapped=True)
+  assert t.container.e.getValue(mapped=True) == 42, \
+      "erroneously statically defined value returned (%s)" % \
+          t.container.e.getValue(mapped=True)
 
   if not k:
     os.system("/bin/rm %s/bindings.py" % this_dir)

--- a/tests/identityref/run.py
+++ b/tests/identityref/run.py
@@ -1,11 +1,13 @@
 #!/usr/bin/env python
 
-import os, sys, getopt
+import os
+import sys
+import getopt
 
-TESTNAME="identityref"
+TESTNAME = "identityref"
+
 
 # generate bindings in this folder
-
 def main():
   try:
     opts, args = getopt.getopt(sys.argv[1:], "k", ["keepfiles"])
@@ -18,32 +20,38 @@ def main():
     if o in ["-k", "--keepfiles"]:
       keepfiles = True
 
-  pyangpath = os.environ.get('PYANGPATH') if os.environ.get('PYANGPATH') is not None else False
-  pyangbindpath = os.environ.get('PYANGBINDPATH') if os.environ.get('PYANGBINDPATH') is not None else False
-  assert not pyangpath == False, "could not find path to pyang"
-  assert not pyangbindpath == False, "could not resolve pyangbind directory"
+  pyangpath = os.environ.get('PYANGPATH') if \
+                os.environ.get('PYANGPATH') is not None else False
+  pyangbindpath = os.environ.get('PYANGBINDPATH') if \
+                os.environ.get('PYANGBINDPATH') is not None else False
+  assert pyangpath is not False, "could not find path to pyang"
+  assert pyangbindpath is not False, "could not resolve pyangbind directory"
 
   this_dir = os.path.dirname(os.path.realpath(__file__))
   os.system("%s --plugindir %s -f pybind \
             -p %s \
-            -o %s/bindings.py %s/%s.yang" % (pyangpath, pyangbindpath, this_dir, this_dir, this_dir, TESTNAME))
+            -o %s/bindings.py %s/%s.yang" % (pyangpath, pyangbindpath,
+                this_dir, this_dir, this_dir, TESTNAME))
 
   from bindings import identityref
 
   i = identityref()
 
   for j in ["id1", "idr1"]:
-    assert hasattr(i.test_container, j), "%s leaf does not exist in the container" % i
+    assert hasattr(i.test_container, j), \
+        "%s leaf does not exist in the container" % i
 
-  assert i.test_container.id1 == "", "id1 leaf had an unexpected value (%s)" % i.test_container.id1
-  assert i.test_container.idr1 == "", "idr1 leaf had an unexpected value (%s)" % i.test_container.idr1
+  assert i.test_container.id1 == "", \
+      "id1 leaf had an unexpected value (%s)" % i.test_container.id1
+  assert i.test_container.idr1 == "", \
+      "idr1 leaf had an unexpected value (%s)" % i.test_container.idr1
 
   passed = True
   try:
     i.test_container.id1 = "hello"
   except ValueError:
     passed = False
-  assert passed == False, "id1 leaf set to invalid value"
+  assert passed is False, "id1 leaf set to invalid value"
 
   for k in ["option-one", "option-two"]:
     passed = True
@@ -52,7 +60,8 @@ def main():
       i.test_container.id1 = k
     except ValueError:
       passed = False
-    assert passed == True, "id1 leaf was set to an invalid value (%s, %s)" % (passed,k)
+    assert passed is True, \
+        "id1 leaf was set to an invalid value (%s, %s)" % (passed, k)
 
   # checks that the namespaces are right
   for k in ["remote-one", "remote-two"]:
@@ -61,7 +70,7 @@ def main():
       i.test_container.idr1 = k
     except ValueError:
       passed = False
-    assert passed == True, "idr1 leaf was set to an invalid value (%s)" % k
+    assert passed is True, "idr1 leaf was set to an invalid value (%s)" % k
 
   if not keepfiles:
     os.system("/bin/rm %s/bindings.py" % this_dir)

--- a/tests/include-import/run.py
+++ b/tests/include-import/run.py
@@ -1,11 +1,13 @@
 #!/usr/bin/env python
 
-import os, sys, getopt
+import os
+import sys
+import getopt
 
-TESTNAME="include-import"
+TESTNAME = "include-import"
+
 
 # generate bindings in this folder
-
 def main():
   try:
     opts, args = getopt.getopt(sys.argv[1:], "k", ["keepfiles"])
@@ -18,18 +20,20 @@ def main():
     if o in ["-k", "--keepfiles"]:
       keepfiles = True
 
-  pyangpath = os.environ.get('PYANGPATH') if os.environ.get('PYANGPATH') is not None else False
-  pyangbindpath = os.environ.get('PYANGBINDPATH') if os.environ.get('PYANGBINDPATH') is not None else False
-  assert not pyangpath == False, "could not find path to pyang"
-  assert not pyangbindpath == False, "could not resolve pyangbind directory"
+  pyangpath = os.environ.get('PYANGPATH') if \
+                os.environ.get('PYANGPATH') is not None else False
+  pyangbindpath = os.environ.get('PYANGBINDPATH') if \
+                os.environ.get('PYANGBINDPATH') is not None else False
+  assert pyangpath is not False, "could not find path to pyang"
+  assert pyangbindpath is not False, "could not resolve pyangbind directory"
 
   this_dir = os.path.dirname(os.path.realpath(__file__))
   os.system("%s --plugindir %s -f pybind \
             -p %s \
-            -o %s/bindings.py %s/%s.yang" % (pyangpath, pyangbindpath, this_dir, this_dir, this_dir, TESTNAME))
+            -o %s/bindings.py %s/%s.yang" % (pyangpath, pyangbindpath,
+                this_dir, this_dir, this_dir, TESTNAME))
 
   from bindings import include_import
-
 
   if not keepfiles:
     os.system("/bin/rm %s/bindings.py" % this_dir)

--- a/tests/int/run.py
+++ b/tests/int/run.py
@@ -1,11 +1,13 @@
 #!/usr/bin/env python
 
-import os, sys, getopt
+import os
+import sys
+import getopt
 
-TESTNAME="int"
+TESTNAME = "int"
+
 
 # generate bindings in this folder
-
 def main():
   try:
     opts, args = getopt.getopt(sys.argv[1:], "k", ["keepfiles"])
@@ -18,13 +20,16 @@ def main():
     if o in ["-k", "--keepfiles"]:
       k = True
 
-  pyangpath = os.environ.get('PYANGPATH') if os.environ.get('PYANGPATH') is not None else False
-  pyangbindpath = os.environ.get('PYANGBINDPATH') if os.environ.get('PYANGBINDPATH') is not None else False
-  assert not pyangpath == False, "could not find path to pyang"
-  assert not pyangbindpath == False, "could not resolve pyangbind directory"
+  pyangpath = os.environ.get('PYANGPATH') if \
+                os.environ.get('PYANGPATH') is not None else False
+  pyangbindpath = os.environ.get('PYANGBINDPATH') if \
+                os.environ.get('PYANGBINDPATH') is not None else False
+  assert pyangpath is not False, "could not find path to pyang"
+  assert pyangbindpath is not False, "could not resolve pyangbind directory"
 
   this_dir = os.path.dirname(os.path.realpath(__file__))
-  os.system("%s --plugindir %s -f pybind -o %s/bindings.py %s/%s.yang" % (pyangpath, pyangbindpath, this_dir, this_dir, TESTNAME))
+  os.system("%s --plugindir %s -f pybind -o %s/bindings.py %s/%s.yang" %
+              (pyangpath, pyangbindpath, this_dir, this_dir, TESTNAME))
 
   from bindings import int_ as i
 
@@ -33,14 +38,15 @@ def main():
   for name in ["eight", "sixteen", "thirtytwo", "sixtyfour"]:
     for subname in ["", "default", "result", "restricted"]:
       assert hasattr(u.int_container, "%s%s" % (name, subname)) == True, \
-        "missing %s%s from container" % (name, subname)
+          "missing %s%s from container" % (name, subname)
 
   # tests default and equality
-  for e in [("eight", 2**7-1), ("sixteen", 2**15-1), ("thirtytwo", 2**31-1), ("sixtyfour", 2**63-1)]:
+  for e in [("eight", 2**7 - 1), ("sixteen", 2**15 - 1),
+            ("thirtytwo", 2**31 - 1), ("sixtyfour", 2**63 - 1)]:
     default_v = getattr(u.int_container, "%sdefault" % e[0])._default
     assert default_v == e[1], \
-      "defaults incorrectly set for %s, expected: %d, got %d" % (e[0], e[1], default_v)
-
+      "defaults incorrectly set for %s, expected: %d, got %d" \
+          % (e[0], e[1], default_v)
 
   u.int_container.eight = 42
   u.int_container.sixteen = 42
@@ -54,7 +60,7 @@ def main():
     v = getattr(u.int_container, i)
     assert v == 42, "incorrectly set %s, expected 42, got %d" % (i, v)
     c = getattr(u.int_container, "_changed")()
-    assert c == True, "incorrect changed flag for %s" % i
+    assert c is True, "incorrect changed flag for %s" % i
 
   # test math + negatives
   u.int_container.eight = 42
@@ -69,7 +75,6 @@ def main():
     v = getattr(u.int_container, i)
     assert v == -42, "incorrectly set %s, expected 42, got %d" % (i, v)
 
-
   for i in ["eight", "sixteen", "thirtytwo", "sixtyfour"]:
     passed = False
     try:
@@ -77,83 +82,96 @@ def main():
       passed = True
     except ValueError:
       pass
-    assert passed == True, "could not set value of %srestricted to 10" % i
+    assert passed is True, "could not set value of %srestricted to 10" % i
 
   e = False
   try:
     u.int_container.eightrestricted = -100
   except ValueError:
     e = True
-  assert e == True, "incorrectly allowed value outside of range for eightrestricted (-100)"
+  assert e is True, \
+      "incorrectly allowed value outside of range for eightrestricted (-100)"
 
   e = False
   try:
     u.int_container.eightrestricted = 1001
   except ValueError:
     e = True
-  assert e == True, "incorrectly allowed value outside of range for eightrestricted (1001)"
+  assert e is True, \
+      "incorrectly allowed value outside of range for eightrestricted (1001)"
 
   e = False
   try:
     u.int_container.sixteenrestricted = -43
   except ValueError:
     e = True
-  assert e == True, "incorrectly allowed value outside of range for sixteenrestricted (-43)"
+  assert e is True, \
+    \
+      "incorrectly allowed value outside of range for sixteenrestricted (-43)"
 
   e = False
   try:
     u.int_container.sixteenrestricted = 1001
   except ValueError:
     e = True
-  assert e == True, "incorrectly allowed value outside of range for sixteenrestricted (1001)"
+  assert e is True, \
+    "incorrectly allowed value outside of range for sixteenrestricted (1001)"
 
   e = False
   try:
     u.int_container.thirtytworestricted = 500001
   except ValueError:
     e = True
-  assert e == True, "incorrectly allowed value outside of range for thirtytworestricted (500001)"
+  assert e is True, \
+    "incorrectly allowed value outside of range for thirtytworestricted " + \
+        "(500001)"
 
   e = False
   try:
     u.int_container.thirtytworestricted = -43
   except ValueError:
     e = True
-  assert e == True, "incorrectly allowed value outside of range for thirtytworestricted (9999)"
+  assert e is True, \
+    "incorrectly allowed value outside of range for thirtytworestricted (9999)"
 
   e = False
   try:
     u.int_container.sixtyfourrestricted = 72036854775809
   except ValueError:
     e = True
-  assert e == True, "incorrectly allowed value outside of range for sixtyfourrestricted (72036854775809)"
+  assert e is True, \
+    "incorrectly allowed value outside of range for sixtyfourrestricted " + \
+        "(72036854775809)"
 
   e = False
   try:
     u.int_container.sixtyfourrestricted = -43
   except ValueError:
     e = True
-  assert e == True, "incorrectly allowed value outside of range for sixtyfourrestricted (-43)"
+  assert e is True, \
+    "incorrectly allowed value outside of range for sixtyfourrestricted (-43)"
 
-  for i in [(0,True), (10,True),(-10,False)]:
+  for i in [(0, True), (10, True), (-10, False)]:
     passed = False
     try:
       u.int_container.restricted_ueight_max = i[0]
       passed = True
     except ValueError:
       pass
-    assert passed == i[1], "restricted range using max was not set correctly (%d -> %s != %s)" % \
-      (i[0], passed, i[1])
+    assert passed == i[1], \
+        "restricted range using max was not set correctly (%d -> %s != %s)" % \
+            (i[0], passed, i[1])
 
-  for i in [(0,True), (13, False), (-20, False), (5, True), (16, True)]:
+  for i in [(0, True), (13, False), (-20, False), (5, True), (16, True)]:
     passed = False
     try:
       u.int_container.complex_range = i[0]
       passed = True
     except ValueError:
       pass
-    assert passed == i[1], "complex range was not set correctly (%d -> %s != %s)" % \
-      (i[0], passed, i[1])
+    assert passed == i[1], \
+        "complex range was not set correctly (%d -> %s != %s)" % \
+            (i[0], passed, i[1])
 
     passed = False
     try:
@@ -161,8 +179,9 @@ def main():
       passed = True
     except ValueError, m:
       pass
-    assert passed == i[1], "complex range with spaces and three elements not set correctly (%d -> %s != %s)" % \
-       (i[0], passed, i[1])
+    assert passed == i[1], \
+        "complex range with spaces and three elements not set correctly " + \
+            "(%d -> %s != %s)" % (i[0], passed, i[1])
 
   for i in [(-2, True), (42, False)]:
     passed = False
@@ -171,29 +190,33 @@ def main():
       passed = True
     except ValueError, m:
       pass
-    assert passed == i[1], "complex range with negatives not set correctly (%d -> %s != %s)" % \
-      (i[0], passed, i[1])
+    assert passed == i[1], \
+         "complex range with negatives not set correctly (%d -> %s != %s)" % \
+              (i[0], passed, i[1])
 
-  for i in [(-11, False), (-5, True), (0, False), (5, False), (10, True), (25, True), (31, False)]:
+  for i in [(-11, False), (-5, True), (0, False), (5, False), (10, True),
+            (25, True), (31, False)]:
     passed = False
     try:
       u.int_container.intLeafWithRange = i[0]
       passed = True
     except ValueError, m:
       pass
-    assert passed == i[1], "complex range with negatives and additional spaces not set correctly (%d -> %s != %s)" % \
-      (i[0], passed, i[1])
+    assert passed == i[1], \
+        "complex range with negatives and additional spaces not set " + \
+            "correctly (%d -> %s != %s)" % (i[0], passed, i[1])
 
-  for i in [(-43, False), (-40, True), (98, False), (122, True), (254, False), (255, True), (256, False)]:
+  for i in [(-43, False), (-40, True), (98, False), (122, True), (254, False),
+            (255, True), (256, False)]:
     passed = False
     try:
       u.int_container.complex_range_with_equals_case = i[0]
       passed = True
     except ValueError, m:
       pass
-    assert passed == i[1], "complex range with equals case was not set correctly (%d -> %s != %s)" % \
-      (i[0], passed, i[1])
-
+    assert passed == i[1], \
+        "complex range with equals case was not set correctly " + \
+            " (%d -> %s != %s)" % (i[0], passed, i[1])
 
   if not k:
     os.system("/bin/rm %s/bindings.py" % this_dir)

--- a/tests/leaf-list/run.py
+++ b/tests/leaf-list/run.py
@@ -1,11 +1,13 @@
 #!/usr/bin/env python
 
-import os, sys, getopt
+import os
+import sys
+import getopt
 
-TESTNAME="leaflist"
+TESTNAME = "leaflist"
+
 
 # generate bindings in this folder
-
 def main():
   try:
     opts, args = getopt.getopt(sys.argv[1:], "k", ["keepfiles"])
@@ -18,14 +20,16 @@ def main():
     if o in ["-k", "--keepfiles"]:
       k = True
 
-  pyangpath = os.environ.get('PYANGPATH') if os.environ.get('PYANGPATH') is not None else False
-  pyangbindpath = os.environ.get('PYANGBINDPATH') if os.environ.get('PYANGBINDPATH') is not None else False
-  assert not pyangpath == False, "could not find path to pyang"
-  assert not pyangbindpath == False, "could not resolve pyangbind directory"
+  pyangpath = os.environ.get('PYANGPATH') if \
+                os.environ.get('PYANGPATH') is not None else False
+  pyangbindpath = os.environ.get('PYANGBINDPATH') if \
+                os.environ.get('PYANGBINDPATH') is not None else False
+  assert pyangpath is not False, "could not find path to pyang"
+  assert pyangbindpath is not False, "could not resolve pyangbind directory"
 
   this_dir = os.path.dirname(os.path.realpath(__file__))
-  os.system("%s --plugindir %s -f pybind -o %s/bindings.py %s/%s.yang" % (pyangpath, pyangbindpath, this_dir, this_dir, TESTNAME))
-
+  os.system("%s --plugindir %s -f pybind -o %s/bindings.py %s/%s.yang" %
+              (pyangpath, pyangbindpath, this_dir, this_dir, TESTNAME))
   from bindings import leaflist
 
   leaflist_instance = leaflist()
@@ -54,7 +58,7 @@ def main():
 
   assert len(leaflist_instance.container.leaflist) == 1, \
     "appended an element to the list erroneously (%s, len %d vs. 1)" % \
-      (leaflist_instance.container.leaflist, \
+      (leaflist_instance.container.leaflist,
         len(leaflist_instance.container.leaflist))
 
   leaflist_instance.container.leaflist.append("itemTwo")
@@ -65,7 +69,7 @@ def main():
   assert leaflist_instance.container.leaflist[1] == "indexOne", \
     "setitem did not set the correct node"
 
-  leaflist_instance.container.leaflist.insert(0,"indexZero")
+  leaflist_instance.container.leaflist.insert(0, "indexZero")
   assert leaflist_instance.container.leaflist[0] == "indexZero", \
     "incorrectly set index 0 value"
   assert len(leaflist_instance.container.leaflist) == 4, \
@@ -76,7 +80,8 @@ def main():
     "list item not succesfully removed by delitem"
 
   assert leaflist_instance.get() == \
-    {'container': {'leaflist': ['itemOne', 'indexOne', 'itemTwo'], 'listtwo': [], 'listthree': []}}, \
+    {'container': {'leaflist': ['itemOne', 'indexOne', 'itemTwo'],
+        'listtwo': [], 'listthree': []}}, \
     "get did not correctly return the dictionary"
 
   try:
@@ -89,33 +94,33 @@ def main():
 
   passed = False
   try:
-    leaflist_instance.container.leaflist = [1,2]
+    leaflist_instance.container.leaflist = [1, 2]
   except ValueError:
     passed = True
-  assert passed == True, "an erroneous value was assigned to the list"
+  assert passed is True, "an erroneous value was assigned to the list"
 
   leaflist_instance.container.listtwo.append("a-valid-string")
-  assert len(leaflist_instance.container.listtwo) == 1, "restricted leaflist did not function correctly"
+  assert len(leaflist_instance.container.listtwo) == 1, \
+      "restricted leaflist did not function correctly"
 
   passed = False
   try:
     leaflist_instance.container.listtwo.append("broken-string")
   except ValueError:
     passed = True
-  assert passed == True, "an erroneous value was assigned to the list (restricted type)"
+  assert passed is True, \
+      "an erroneous value was assigned to the list (restricted type)"
 
-
-  for i in [(1,True), ("fish", True), ([], False)]:
+  for i in [(1, True), ("fish", True), ([], False)]:
     passed = False
     try:
       leaflist_instance.container.listthree.append(i[0])
       passed = True
     except ValueError:
       pass
-    assert passed == i[1], "leaf-list of union type had invalid result (%s != %s for %s)" \
-      % (passed, i[1], i[0])
-
-
+    assert passed == i[1], \
+        "leaf-list of union type had invalid result (%s != %s for %s)" \
+            % (passed, i[1], i[0])
 
   if not k:
     os.system("/bin/rm %s/bindings.py" % this_dir)

--- a/tests/list/run.py
+++ b/tests/list/run.py
@@ -1,11 +1,13 @@
 #!/usr/bin/env python
 
-import os, sys, getopt
+import os
+import sys
+import getopt
 
-TESTNAME="list"
+TESTNAME = "list"
+
 
 # generate bindings in this folder
-
 def main():
   try:
     opts, args = getopt.getopt(sys.argv[1:], "k", ["keepfiles"])
@@ -18,13 +20,16 @@ def main():
     if o in ["-k", "--keepfiles"]:
       k = True
 
-  pyangpath = os.environ.get('PYANGPATH') if os.environ.get('PYANGPATH') is not None else False
-  pyangbindpath = os.environ.get('PYANGBINDPATH') if os.environ.get('PYANGBINDPATH') is not None else False
-  assert not pyangpath == False, "could not find path to pyang"
-  assert not pyangbindpath == False, "could not resolve pyangbind directory"
+  pyangpath = os.environ.get('PYANGPATH') if \
+                os.environ.get('PYANGPATH') is not None else False
+  pyangbindpath = os.environ.get('PYANGBINDPATH') if \
+                os.environ.get('PYANGBINDPATH') is not None else False
+  assert pyangpath is not False, "could not find path to pyang"
+  assert pyangbindpath is not False, "could not resolve pyangbind directory"
 
   this_dir = os.path.dirname(os.path.realpath(__file__))
-  os.system("%s --plugindir %s -f pybind -o %s/bindings.py %s/%s.yang" % (pyangpath, pyangbindpath, this_dir, this_dir, TESTNAME))
+  os.system("%s --plugindir %s -f pybind -o %s/bindings.py %s/%s.yang" %
+              (pyangpath, pyangbindpath, this_dir, this_dir, TESTNAME))
 
   from bindings import list_ as l
 
@@ -55,22 +60,26 @@ def main():
   assert test_instance.list_container.list_element[1].keyval == 1, \
     "keyvalue is not set as per list key by default"
 
-  assert (not test_instance.list_container.list_element[1].another_value == "defaultValue"), \
-    "list value is equal to default value without being set"
+  assert (not test_instance.list_container.list_element[1].another_value ==
+     "defaultValue"), \
+          "list value is equal to default value without being set"
 
   test_instance.list_container.list_element.add(2)
-  test_instance.list_container.list_element[2].another_value == "aSecondDefaultValue"
+  test_instance.list_container.list_element[2].another_value == \
+      "aSecondDefaultValue"
 
   assert test_instance.get() == \
-    {'list-container': {'list-seven': {}, 'list-six': {}, 'list-five': {}, 'list-two': {}, 'list-three': {}, 'list-four': {},
-    'list-element': {1: {'keyval': 1, 'another-value': 'defaultValue'},
+    {'list-container': {'list-seven': {}, 'list-six': {}, 'list-five': {},
+        'list-two': {}, 'list-three': {}, 'list-four': {},
+        'list-element': {1: {'keyval': 1, 'another-value': 'defaultValue'},
     2: {'keyval': 2, 'another-value': 'defaultValue'}}}}, \
     "incorrect get() output returned: %s" % test_instance.get()
   del test_instance.list_container.list_element[2]
 
   test_instance.list_container.list_element[1].another_value = "aTestValue"
-  assert test_instance.list_container.list_element[1].another_value == "aTestValue", \
-    "list value is not set correctly when specified"
+  assert test_instance.list_container.list_element[1].another_value == \
+      "aTestValue", \
+        "list value is not set correctly when specified"
 
   del test_instance.list_container.list_element[1]
   assert len(test_instance.list_container.list_element) == 0, \
@@ -89,12 +98,15 @@ def main():
       test_instance.list_container.list_two.add(i)
     except KeyError:
       if i not in ["bear", "chicken"]:
-        assert False, "invalid item added to a list with a restricted key, %s" % i
+        assert False, \
+            "invalid item added to a list with a restricted key, %s" % i
     try:
       test_instance.list_container.list_three.add(i)
     except KeyError:
       if i not in ["chicken"]:
-        assert False, "invalid item added to a list with a union restricted key, %s" % i
+        assert False, \
+            "invalid item added to a list with a union restricted" + \
+            " key, %s" % i
 
   passed = False
   test_instance.list_container.list_element.add(22)
@@ -102,35 +114,40 @@ def main():
     test_instance.list_container.list_element[22].keyval = 14
   except AttributeError:
     passed = True
-  assert passed, "keyvalue of a list was read-write when it should be read-only"
+  assert passed, \
+    "keyvalue of a list was read-write when it should be read-only"
 
-  for i in [("aardvark 5", True), ("bear 7", True), ("chicken 5", False), ("bird 11",False)]:
+  for i in [("aardvark 5", True), ("bear 7", True), ("chicken 5", False),
+            ("bird 11", False)]:
     try:
       test_instance.list_container.list_four.add(i[0])
       added = True
     except KeyError:
       added = False
-    assert added == i[1], "list element erroneously added to multiple-key list (%s,%s)" % i
+    assert added == i[1], \
+        "list element erroneously added to multiple-key list (%s,%s)" % i
 
-  for i in range(1,10):
+  for i in range(1, 10):
     test_instance.list_container.list_five.add(i)
 
-  for i,j in zip(test_instance.list_container.list_five.keys(), range(1,10)):
-    assert i == j, "ordered list had incorrect key ordering (%d != %d)" % (i,j)
+  for i, j in zip(test_instance.list_container.list_five.keys(), range(1, 10)):
+    assert i == j, "ordered list had incorrect key ordering (%d != %d)" \
+        % (i, j)
 
   passed = False
   try:
     test_instance.list_container.list_five.add()
   except KeyError:
     passed = True
-  assert passed == True, "a list with a key value allowed an key-less value to be set"
+  assert passed is True, \
+      "a list with a key value allowed an key-less value to be set"
 
   x = test_instance.list_container.list_six.add()
   test_instance.list_container.list_six[x]._set_val(10)
 
   assert test_instance.list_container.list_six[x].val == 10, \
     "a key-less list did not have the correct value set (%s %d != 10)" % \
-      (x,test_instance.list_container.list_six[x].val)
+      (x, test_instance.list_container.list_six[x].val)
 
   if not k:
     os.system("/bin/rm %s/bindings.py" % this_dir)

--- a/tests/nested-containers/run.py
+++ b/tests/nested-containers/run.py
@@ -1,11 +1,13 @@
 #!/usr/bin/env python
 
-import os, sys, getopt
+import os
+import sys
+import getopt
 
-TESTNAME="nested"
+TESTNAME = "nested"
+
 
 # generate bindings in this folder
-
 def main():
   try:
     opts, args = getopt.getopt(sys.argv[1:], "k", ["keepfiles"])
@@ -18,13 +20,16 @@ def main():
     if o in ["-k", "--keepfiles"]:
       k = True
 
-  pyangpath = os.environ.get('PYANGPATH') if os.environ.get('PYANGPATH') is not None else False
-  pyangbindpath = os.environ.get('PYANGBINDPATH') if os.environ.get('PYANGBINDPATH') is not None else False
-  assert not pyangpath == False, "could not find path to pyang"
-  assert not pyangbindpath == False, "could not resolve pyangbind directory"
+  pyangpath = os.environ.get('PYANGPATH') if \
+                os.environ.get('PYANGPATH') is not None else False
+  pyangbindpath = os.environ.get('PYANGBINDPATH') if \
+                os.environ.get('PYANGBINDPATH') is not None else False
+  assert pyangpath is not False, "could not find path to pyang"
+  assert pyangbindpath is not False, "could not resolve pyangbind directory"
 
   this_dir = os.path.dirname(os.path.realpath(__file__))
-  os.system("%s --plugindir %s -f pybind -o %s/bindings.py %s/%s.yang" % (pyangpath, pyangbindpath, this_dir, this_dir, TESTNAME))
+  os.system("%s --plugindir %s -f pybind -o %s/bindings.py %s/%s.yang" %
+              (pyangpath, pyangbindpath, this_dir, this_dir, TESTNAME))
 
   from bindings import nested
 
@@ -47,8 +52,9 @@ def main():
   assert test_instance.container.get() == {'subcontainer': {'a-leaf': 1}}, \
     "container get not correct"
 
-  assert test_instance.get() == {'container': {'subcontainer': {'a-leaf': 1}}}, \
-    "instance get not correct"
+  assert test_instance.get() == \
+    {'container': {'subcontainer': {'a-leaf': 1}}}, \
+      "instance get not correct"
 
   if not k:
     os.system("/bin/rm %s/bindings.py" % this_dir)

--- a/tests/openconfig-bgp-juniper/run.py
+++ b/tests/openconfig-bgp-juniper/run.py
@@ -1,11 +1,13 @@
 #!/usr/bin/env python
 
-import os, sys, getopt
+import os
+import sys
+import getopt
 
-TESTNAME="openconfig-bgp-juniper"
+TESTNAME = "openconfig-bgp-juniper"
+
 
 # generate bindings in this folder
-
 def main():
   try:
     opts, args = getopt.getopt(sys.argv[1:], "k", ["keepfiles"])
@@ -18,18 +20,20 @@ def main():
     if o in ["-k", "--keepfiles"]:
       k = True
 
-  pyangpath = os.environ.get('PYANGPATH') if os.environ.get('PYANGPATH') is not None else False
-  pyangbindpath = os.environ.get('PYANGBINDPATH') if os.environ.get('PYANGBINDPATH') is not None else False
-  assert not pyangpath == False, "could not find path to pyang"
-  assert not pyangbindpath == False, "could not resolve pyangbind directory"
+  pyangpath = os.environ.get('PYANGPATH') if \
+                os.environ.get('PYANGPATH') is not None else False
+  pyangbindpath = os.environ.get('PYANGBINDPATH') if \
+                os.environ.get('PYANGBINDPATH') is not None else False
+  assert pyangpath is not False, "could not find path to pyang"
+  assert pyangbindpath is not False, "could not resolve pyangbind directory"
 
   this_dir = os.path.dirname(os.path.realpath(__file__))
-  os.system("%s --plugindir %s -f pybind -o %s/bindings.py %s/%s.yang" % (pyangpath, pyangbindpath, this_dir, this_dir, TESTNAME))
-
+  os.system("%s --plugindir %s -f pybind -o %s/bindings.py %s/%s.yang" %
+              (pyangpath, pyangbindpath, this_dir, this_dir, TESTNAME))
 
   from bindings import openconfig_bgp_juniper
 
-  global_config = {"my_as": 2856,}
+  global_config = {"my_as": 2856}
   peer_group_list = ["groupA", "groupB"]
   peers = [("1.1.1.1", "groupA", 3741), ("1.1.1.2", "groupA", 5400,),
           ("1.1.1.3", "groupA", 29636), ("2.2.2.2", "groupB", 12767)]
@@ -42,8 +46,9 @@ def main():
   except AttributeError:
     except_thrown = True
 
-  assert except_thrown == True, "Trying to set a missing container did not result" + \
-    " in an attribute error (%s != True)" % except_thrown
+  assert except_thrown is True, \
+    "Trying to set a missing container did not result" + \
+      " in an attribute error (%s != True)" % except_thrown
 
   bgp.juniper_config.bgp.global_.as_ = global_config["my_as"]
   for peer_group in peer_group_list:
@@ -51,35 +56,91 @@ def main():
 
   for peer in peers:
     bgp.juniper_config.bgp.peer_group[peer[1]].neighbor.add(peer[0])
-    bgp.juniper_config.bgp.peer_group[peer[1]].neighbor[peer[0]].peer_as = peer[2]
+    bgp.juniper_config.bgp.peer_group[peer[1]].neighbor[peer[0]].peer_as = \
+        peer[2]
 
+  bgp_filter_response = {
+      'juniper-config': {
+          'bgp': {
+              'global': {
+                  'as': '2856'
+              },
+              'peer-group': {
+                  'groupA': {
+                      'group-name': 'groupA',
+                      'neighbor': {
+                          '1.1.1.1': {
+                              'neighbor-name': '1.1.1.1',
+                              'peer-as': '3741'
+                          },
+                          '1.1.1.2': {
+                              'neighbor-name': '1.1.1.2',
+                              'peer-as': '5400'
+                          },
+                          '1.1.1.3': {
+                              'neighbor-name': '1.1.1.3',
+                              'peer-as': '29636'
+                          }
+                      }
+                  },
+                  'groupB': {
+                      'group-name': 'groupB',
+                      'neighbor': {
+                          '2.2.2.2': {
+                              'neighbor-name': '2.2.2.2',
+                              'peer-as': '12767'
+                          }
+                      }
+                  }
+              }
+          }
+      }
+  }
 
-  bgp_filter_response = {'juniper-config': {'bgp': {'global': {'as': '2856'},
-                            'peer-group': {'groupA': {'group-name': 'groupA',
-                                                      'neighbor': {'1.1.1.1': {'neighbor-name': '1.1.1.1',
-                                                                               'peer-as': '3741'},
-                                                                   '1.1.1.2': {'neighbor-name': '1.1.1.2',
-                                                                               'peer-as': '5400'},
-                                                                   '1.1.1.3': {'neighbor-name': '1.1.1.3',
-                                                                               'peer-as': '29636'}}},
-                                           'groupB': {'group-name': 'groupB',
-                                                      'neighbor': {'2.2.2.2': {'neighbor-name': '2.2.2.2',
-                                                                               'peer-as': '12767'}}}}}}}
-  bgp_unfilter_response = {'juniper-config': {'bgp': {'global': {'as': '2856'},
-                            'peer-group': {'groupA': {'group-name': 'groupA',
-                                                      'neighbor': {'1.1.1.1': {'neighbor-name': '1.1.1.1',
-                                                                               'peer-as': '3741'},
-                                                                   '1.1.1.2': {'neighbor-name': '1.1.1.2',
-                                                                               'peer-as': '5400'},
-                                                                   '1.1.1.3': {'neighbor-name': '1.1.1.3',
-                                                                               'peer-as': '29636'}},
-                                                      'peer-type': ''},
-                                           'groupB': {'group-name': 'groupB',
-                                                      'neighbor': {'2.2.2.2': {'neighbor-name': '2.2.2.2',
-                                                                               'peer-as': '12767'}},
-                                                      'peer-type': ''}}}}}
-  assert bgp.get() == bgp_unfilter_response, "unfiltered get response did not match"
-  assert bgp.get(filter=True) == bgp_filter_response, "filtered get response did not match"
+  bgp_unfilter_response = {
+      'juniper-config': {
+          'bgp': {
+              'global': {
+                  'as': '2856'
+              },
+              'peer-group': {
+                  'groupA': {
+                      'group-name': 'groupA',
+                      'neighbor': {
+                          '1.1.1.1': {
+                              'neighbor-name': '1.1.1.1',
+                              'peer-as': '3741'
+                          },
+                          '1.1.1.2': {
+                              'neighbor-name': '1.1.1.2',
+                              'peer-as': '5400'
+                          },
+                          '1.1.1.3': {
+                              'neighbor-name': '1.1.1.3',
+                              'peer-as': '29636'
+                          }
+                      },
+                      'peer-type': '',
+                  },
+                  'groupB': {
+                      'group-name': 'groupB',
+                      'neighbor': {
+                          '2.2.2.2': {
+                              'neighbor-name': '2.2.2.2',
+                              'peer-as': '12767'
+                          }
+                      },
+                      'peer-type': ''
+                  }
+              }
+          }
+      }
+  }
+
+  assert bgp.get() == bgp_unfilter_response, "unfiltered get response " + \
+      "did not match"
+  assert bgp.get(filter=True) == bgp_filter_response, \
+      "filtered get response did not match"
 
   if not k:
     os.system("/bin/rm %s/bindings.py" % this_dir)

--- a/tests/serialise/json/run.py
+++ b/tests/serialise/json/run.py
@@ -1,12 +1,15 @@
 #!/usr/bin/env python
 
-import os, sys, getopt, json
+import os
+import sys
+import getopt
+import json
 from lib.serialise import pybindJSONEncoder
 
-TESTNAME="serialise-json"
+TESTNAME = "serialise-json"
+
 
 # generate bindings in this folder
-
 def main():
   try:
     opts, args = getopt.getopt(sys.argv[1:], "k", ["keepfiles"])
@@ -19,13 +22,16 @@ def main():
     if o in ["-k", "--keepfiles"]:
       k = True
 
-  pyangpath = os.environ.get('PYANGPATH') if os.environ.get('PYANGPATH') is not None else False
-  pyangbindpath = os.environ.get('PYANGBINDPATH') if os.environ.get('PYANGBINDPATH') is not None else False
-  assert not pyangpath == False, "could not find path to pyang"
-  assert not pyangbindpath == False, "could not resolve pyangbind directory"
+  pyangpath = os.environ.get('PYANGPATH') if \
+                os.environ.get('PYANGPATH') is not None else False
+  pyangbindpath = os.environ.get('PYANGBINDPATH') if \
+                os.environ.get('PYANGBINDPATH') is not None else False
+  assert pyangpath is not False, "could not find path to pyang"
+  assert pyangbindpath is not False, "could not resolve pyangbind directory"
 
   this_dir = os.path.dirname(os.path.realpath(__file__))
-  os.system("%s --plugindir %s -f pybind -o %s/bindings.py %s/%s.yang" % (pyangpath, pyangbindpath, this_dir, this_dir, TESTNAME))
+  os.system("%s --plugindir %s -f pybind -o %s/bindings.py %s/%s.yang" %
+              (pyangpath, pyangbindpath, this_dir, this_dir, TESTNAME))
 
   from bindings import serialise_json
   js = serialise_json()
@@ -33,10 +39,10 @@ def main():
   js.c1.l1.add(1)
   for s in ["int", "uint"]:
     for l in [8, 16, 32, 64]:
-      name = "%s%s" % (s,l)
-      x=getattr(js.c1.l1[1], "_set_%s" % name)
+      name = "%s%s" % (s, l)
+      x = getattr(js.c1.l1[1], "_set_%s" % name)
       x(1)
-  js.c1.l1[1].restricted_integer = 6;
+  js.c1.l1[1].restricted_integer = 6
   js.c1.l1[1].string = "bear"
   js.c1.l1[1].restricted_string = "aardvark"
   js.c1.l1[1].union = 16
@@ -55,48 +61,12 @@ def main():
   js.c1.l1[1].typedef_two = 8
   js.c1.l1[1].one_leaf = "hi"
 
+  # print js.get()
 
-  print js.get()
-
-  for i in range(1,10):
+  for i in range(1, 10):
     js.c1.l2.add(i)
 
   print json.dumps(js.get(), cls=pybindJSONEncoder, indent=4)
-
-
-  # from ocbindings import bgp
-  # from lib.xpathhelper import YANGPathHelper
-
-  # ph = YANGPathHelper()
-
-  # ocbgp = bgp(path_helper=ph)
-
-  # add_peers = [
-  #               ("192.168.1.1", "2856", "linx-peers"),
-  #               ("172.16.12.2", "3356", "transit"),
-  #               ("10.0.0.3", "5400", "private-peers"),
-  #               ("10.0.0.4", "3300", "private-peers"),
-  #               ("192.168.1.2", "6871", "linx-peers")
-  #             ]
-
-  # for e in add_peers:
-  #   if not e[2] in ocbgp.bgp.peer_groups.peer_group:
-  #     ocbgp.bgp.peer_groups.peer_group.add(e[2])
-  #   if not e[0] in ocbgp.bgp.neighbors.neighbor:
-  #     ocbgp.bgp.neighbors.neighbor.add(e[0])
-  #     ocbgp.bgp.neighbors.neighbor[e[0]].config.peer_group = e[2]
-  #     ocbgp.bgp.neighbors.neighbor[e[0]].config.peer_type = "EXTERNAL"
-  #     ocbgp.bgp.neighbors.neighbor[e[0]].config.send_community = "STANDARD"
-  #     ocbgp.bgp.neighbors.neighbor[e[0]].route_reflector.config.route_reflector_client = True
-  #     ocbgp.bgp.neighbors.neighbor[e[0]].route_reflector.config.route_reflector_cluster_id = "192.168.1.1"
-
-
-  # #ocbgp.bgp.neighbors.neighbor.add("42.42.42.42")
-  # #ocbgp.bgp.neighbors.neighbor["42.42.42.42"].config.peer_group = "DOES NOT EXIST!"
-
-  # print ocbgp.bgp.peer_groups.get(filter=True)
-
-  # print json.dumps(ocbgp.get(), cls=pybindJSONEncoder, indent=4)
 
   if not k:
     os.system("/bin/rm %s/bindings.py" % this_dir)

--- a/tests/serialise/serialise_tests.sh
+++ b/tests/serialise/serialise_tests.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # set to true or false
-DEL=false
+DEL=true
 FAIL=0
 
 TESTDIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/tests/split-classes/run.py
+++ b/tests/split-classes/run.py
@@ -1,11 +1,13 @@
 #!/usr/bin/env python
 
-import os, sys, getopt
+import os
+import sys
+import getopt
 
-TESTNAME="split-classes"
+TESTNAME = "split-classes"
+
 
 # generate bindings in this folder
-
 def main():
   try:
     opts, args = getopt.getopt(sys.argv[1:], "k", ["keepfiles"])
@@ -18,14 +20,17 @@ def main():
     if o in ["-k", "--keepfiles"]:
       keepfiles = True
 
-  pyangpath = os.environ.get('PYANGPATH') if os.environ.get('PYANGPATH') is not None else False
-  pyangbindpath = os.environ.get('PYANGBINDPATH') if os.environ.get('PYANGBINDPATH') is not None else False
-  assert not pyangpath == False, "could not find path to pyang"
-  assert not pyangbindpath == False, "could not resolve pyangbind directory"
+  pyangpath = os.environ.get('PYANGPATH') if \
+                os.environ.get('PYANGPATH') is not None else False
+  pyangbindpath = os.environ.get('PYANGBINDPATH') if \
+                os.environ.get('PYANGBINDPATH') is not None else False
+  assert pyangpath is not False, "could not find path to pyang"
+  assert pyangbindpath is not False, "could not resolve pyangbind directory"
 
   this_dir = os.path.dirname(os.path.realpath(__file__))
-  print this_dir
-  os.system("%s --plugindir %s -f pybind --split-class-dir=%s/bindings --pybind-class-dir=%s %s/%s.yang" % (pyangpath, pyangbindpath, this_dir, pyangbindpath, this_dir, TESTNAME))
+  os.system(("%s --plugindir %s -f pybind --split-class-dir=%s/bindings " +
+        "--pybind-class-dir=%s %s/%s.yang") % (pyangpath, pyangbindpath,
+            this_dir, pyangbindpath, this_dir, TESTNAME))
 
   from bindings import split_classes
 
@@ -37,7 +42,9 @@ def main():
     passed = True
   except ValueError:
     passed = False
-  assert passed == True, "Module name matching first level container name resulted in invalid file"
+
+  assert passed is True, "Module name matching first level container name " + \
+      "resulted in invalid file"
 
   passed = None
   try:
@@ -46,7 +53,8 @@ def main():
   except ValueError:
     passed = False
 
-  assert passed == True, "Hiearchy of same named containers resulted in an invalid file"
+  assert passed is True, "Hiearchy of same named containers " + \
+      "resulted in an invalid file"
 
   if not keepfiles:
     os.system("/bin/rm -rf %s/bindings" % this_dir)

--- a/tests/string/run.py
+++ b/tests/string/run.py
@@ -1,11 +1,13 @@
 #!/usr/bin/env python
 
-import os, sys, getopt
+import os
+import sys
+import getopt
 
-TESTNAME="string"
+TESTNAME = "string"
+
 
 # generate bindings in this folder
-
 def main():
   try:
     opts, args = getopt.getopt(sys.argv[1:], "k", ["keepfiles"])
@@ -18,20 +20,23 @@ def main():
     if o in ["-k", "--keepfiles"]:
       k = True
 
-  pyangpath = os.environ.get('PYANGPATH') if os.environ.get('PYANGPATH') is not None else False
-  pyangbindpath = os.environ.get('PYANGBINDPATH') if os.environ.get('PYANGBINDPATH') is not None else False
-  assert not pyangpath == False, "could not find path to pyang"
-  assert not pyangbindpath == False, "could not resolve pyangbind directory"
+  pyangpath = os.environ.get('PYANGPATH') if \
+                os.environ.get('PYANGPATH') is not None else False
+  pyangbindpath = os.environ.get('PYANGBINDPATH') if \
+                os.environ.get('PYANGBINDPATH') is not None else False
+  assert pyangpath is not False, "could not find path to pyang"
+  assert pyangbindpath is not False, "could not resolve pyangbind directory"
 
   this_dir = os.path.dirname(os.path.realpath(__file__))
-  os.system("%s --plugindir %s -f pybind -o %s/bindings.py %s/%s.yang" % (pyangpath, pyangbindpath, this_dir, this_dir, TESTNAME))
+  os.system("%s --plugindir %s -f pybind -o %s/bindings.py %s/%s.yang" %
+              (pyangpath, pyangbindpath, this_dir, this_dir, TESTNAME))
 
   from bindings import string
   test_instance = string()
   assert hasattr(test_instance, "string_container"), \
         "string_container does not exist"
 
-  assert hasattr(test_instance.string_container, \
+  assert hasattr(test_instance.string_container,
         "string_leaf"), "string_leaf does not exist"
 
   assert hasattr(test_instance.string_container, "string_default_leaf"), \
@@ -40,8 +45,9 @@ def main():
   assert hasattr(test_instance.string_container, "restricted_string"), \
         "restricted_string does not exist"
 
-  assert hasattr(test_instance.string_container, "restricted_string_default"), \
-        "restricted_string with default does not exist"
+  assert hasattr(test_instance.string_container,
+        "restricted_string_default"), \
+            "restricted_string with default does not exist"
 
   assert test_instance.string_container.string_leaf._changed() == False, \
         "string_leaf erroneously set to changed (value: %s)" % \
@@ -62,20 +68,24 @@ def main():
           test_instance.string_container.string_leaf
 
   assert test_instance.string_container.string_default_leaf == "", \
-        "string_default_leaf did not have the correct empty default value (value: %s)" % \
-          test_instance.string_container.string_default_leaf
+        "string_default_leaf did not have the correct empty default value " + \
+            "(value: %s)" % test_instance.string_container.string_default_leaf
 
-  assert test_instance.string_container.string_default_leaf._default == "string", \
-        "string_default_leaf did not have the correct hidden default value (value: %s)" % \
-          test_instance.string_container.string_default_leaf._default
+  assert test_instance.string_container.string_default_leaf._default == \
+        "string", "string_default_leaf did not have the correct hidden " + \
+            "default value (value: %s)" % \
+                test_instance.string_container.string_default_leaf._default
 
-  assert test_instance.string_container.restricted_string_default._default == "beep", \
-        "restricted_string_default did not have the correct hidden defualt value (value: %s)" % \
-          test_instance.string_container.restricted_string_default
+  assert test_instance.string_container.restricted_string_default._default == \
+      "beep", \
+        "restricted_string_default did not have the correct hidden default " \
+            "value (value: %s)" % \
+                test_instance.string_container.restricted_string_default
 
-  assert test_instance.string_container.string_default_leaf._changed() == False, \
-        "string_default_leaf erroneously reports having been changed (value: %s)" % \
-          test_instance.string_container.string_default_leaf._changed()
+  assert test_instance.string_container.string_default_leaf._changed() == \
+      False, "string_default_leaf erroneously reports having been changed" + \
+          "(value: %s)" % \
+              test_instance.string_container.string_default_leaf._changed()
 
   test_instance.string_container.restricted_string = "aardvark"
   assert test_instance.string_container.restricted_string == "aardvark", \
@@ -91,7 +101,8 @@ def main():
   assert test_instance.string_container.restricted_string == "aardvark", \
         "restricted string was changed in value to invalid (value: %s)" % \
           test_instance.string_container.restricted_string
-  assert exception_raised == True, "exception was not raised when invalid value set"
+  assert exception_raised is True, \
+      "exception was not raised when invalid value set"
 
   for tc in [("a", False), ("ab", True), ("abc", False)]:
     try:
@@ -99,46 +110,55 @@ def main():
       passed = True
     except ValueError:
       passed = False
-    assert passed == tc[1], "restricted len string was incorrectly set (%s -> %s exp: %s)" \
-        % (tc[0], passed, tc[1])
-
+    assert passed == tc[1], "restricted len string was incorrectly set " + \
+      "(%s -> %s exp: %s)" \
+          % (tc[0], passed, tc[1])
 
   for tc in [("a", False), ("b", False), ("abc", False), ("ab", True)]:
     try:
-      test_instance.string_container.restricted_length_and_pattern_string = tc[0]
+      test_instance.string_container.restricted_length_and_pattern_string = \
+          tc[0]
       passed = True
     except ValueError:
       passed = False
-    assert passed == tc[1], "restricted len and pattern string was incorrectly set" + \
-      "(%s-> %s exp: %s)" % (tc[0], passed, tc[1])
+    assert passed == tc[1], \
+        "restricted len and pattern string was incorrectly set" + \
+            "(%s-> %s exp: %s)" % (tc[0], passed, tc[1])
 
   for tc in [("short", False), ("loooooooong", True)]:
     try:
-      test_instance.string_container.restricted_length_string_with_range = tc[0]
+      test_instance.string_container.restricted_length_string_with_range = \
+          tc[0]
       passed = True
     except ValueError:
       passed = False
-    assert passed == tc[1], "restricted length range string was incorrectly set" + \
-      "(%s -> %s exp: %s)" % (tc[0], passed, tc[1])
+    assert passed == tc[1], \
+        "restricted length range string was incorrectly set" + \
+            "(%s -> %s exp: %s)" % (tc[0], passed, tc[1])
 
-  for tc in [("short", False), ("loooooooong", True), ("toooooooooolooooooooong", False)]:
+  for tc in [("short", False), ("loooooooong", True),
+             ("toooooooooolooooooooong", False)]:
     try:
       test_instance.string_container.restricted_length_string_range_two = tc[0]
       passed = True
     except ValueError:
       passed = False
-    assert passed == tc[1], "restricted length range string two was incorrectly set" + \
-      "(%s -> %s exp: %s)" % (tc[0], passed, tc[1])
+    assert passed == tc[1], \
+        "restricted length range string two was incorrectly set" + \
+            "(%s -> %s exp: %s)" % (tc[0], passed, tc[1])
 
-  for tc in [("strLength10", True), ("LengthTwelve", True), ("strTwentyOneCharsLong", False),
-             ("aReallyLongStringMoreThan30CharsLong", True), ("anEvenLongerStringThatIsMoreThanFortyChars", False)]:
+  for tc in [("strLength10", True), ("LengthTwelve", True),
+             ("strTwentyOneCharsLong", False),
+             ("aReallyLongStringMoreThan30CharsLong", True),
+             ("anEvenLongerStringThatIsMoreThanFortyChars", False)]:
     try:
       test_instance.string_container.stringLeafWithComplexLength = tc[0]
       passed = True
     except ValueError:
       passed = False
-    assert passed == tc[1], "stringLeafWithComplexLength set to %s incorrectly (%s != %s)" % \
-        (tc[0], tc[1], passed)
+    assert passed == tc[1], \
+        "stringLeafWithComplexLength set to %s incorrectly (%s != %s)" % \
+            (tc[0], tc[1], passed)
 
   if not k:
     os.system("/bin/rm %s/bindings.py" % this_dir)

--- a/tests/typedef/run.py
+++ b/tests/typedef/run.py
@@ -1,11 +1,13 @@
 #!/usr/bin/env python
 
-import os, sys, getopt
+import os
+import sys
+import getopt
 
-TESTNAME="typedef"
+TESTNAME = "typedef"
+
 
 # generate bindings in this folder
-
 def main():
   try:
     opts, args = getopt.getopt(sys.argv[1:], "k", ["keepfiles"])
@@ -18,22 +20,27 @@ def main():
     if o in ["-k", "--keepfiles"]:
       k = True
 
-  pyangpath = os.environ.get('PYANGPATH') if os.environ.get('PYANGPATH') is not None else False
-  pyangbindpath = os.environ.get('PYANGBINDPATH') if os.environ.get('PYANGBINDPATH') is not None else False
-  assert not pyangpath == False, "could not find path to pyang"
-  assert not pyangbindpath == False, "could not resolve pyangbind directory"
+  pyangpath = os.environ.get('PYANGPATH') if \
+                os.environ.get('PYANGPATH') is not None else False
+  pyangbindpath = os.environ.get('PYANGBINDPATH') if \
+                os.environ.get('PYANGBINDPATH') is not None else False
+  assert pyangpath is not False, "could not find path to pyang"
+  assert pyangbindpath is not False, "could not resolve pyangbind directory"
 
   this_dir = os.path.dirname(os.path.realpath(__file__))
   os.system("%s --plugindir %s -f pybind \
             -p %s \
-            -o %s/bindings.py %s/%s.yang" % (pyangpath, pyangbindpath, this_dir, this_dir, this_dir, TESTNAME))
+            -o %s/bindings.py %s/%s.yang" % (pyangpath, pyangbindpath,
+                this_dir, this_dir, this_dir, TESTNAME))
 
   from bindings import typedef
   t = typedef()
 
-  for element in ["string", "integer", "stringdefault", "integerdefault", \
-                  "new_string", "remote_new_type", "session_dir", "remote_local_type"]:
-    assert hasattr(t.container, element), "element %s did not exist within the container" % element
+  for element in ["string", "integer", "stringdefault", "integerdefault",
+                  "new_string", "remote_new_type", "session_dir",
+                  "remote_local_type"]:
+    assert hasattr(t.container, element), \
+        "element %s did not exist within the container" % element
 
   t.container.string = "hello"
   assert t.container.string == "hello", \
@@ -41,8 +48,8 @@ def main():
     % t.container.string
 
   assert t.container.stringdefault._default == "aDefaultValue", \
-    "incorrect default value for derived string type with a default (value: %s)" % \
-    t.container.stringdefault._default
+    "incorrect default value for derived string type with a default " + \
+    "(value: %s)" % t.container.stringdefault._default
 
   assert t.container.new_string._default == "defaultValue", \
     "incorrect default value where derived from typedef (value: %s)" % \
@@ -54,11 +61,11 @@ def main():
 
   passed = False
   try:
-    t.container.integer = 65 # outside of range
+    t.container.integer = 65  # outside of range
   except ValueError:
     passed = True
 
-  assert passed == True, "restricted int from typedef was set to invalid value"
+  assert passed is True, "restricted int from typedef was set to invalid value"
 
   t.container.remote_new_type = "testString"
   assert t.container.remote_new_type == "testString", \
@@ -70,7 +77,7 @@ def main():
     "incorrect value for remote definition which had local definition (%s)" % \
       t.container.remote_local_type
 
-  for i in [("aardvark", True), ("ant", False), ("duck",False)]:
+  for i in [("aardvark", True), ("ant", False), ("duck", False)]:
     wset = True
     try:
       t.container.inheritance = i[0]
@@ -78,9 +85,9 @@ def main():
       wset = False
     assert wset == i[1], \
       "inherited pattern was not correctly followed for %s (%s != %s)" \
-        % (i[0],i[1],wset)
+        % (i[0], i[1], wset)
 
-  for i in [(2,True),(10,False),(1,False)]:
+  for i in [(2, True), (10, False), (1, False)]:
     wset = True
     try:
       t.container.int_inheritance = i[0]
@@ -90,13 +97,16 @@ def main():
       "inherited range was not correctly followed for %s (%s != %s)" \
         % (i[0], i[1], wset)
 
-  for i in [("aardvark", True), ("bear", True), ("chicken", False), ("deer", False), ("zebra", True)]:
+  for i in [("aardvark", True), ("bear", True), ("chicken", False),
+            ("deer", False), ("zebra", True)]:
     try:
       t.container.stacked_union.append(i[0])
       passed = True
     except ValueError:
       passed = False
-    assert passed == i[1], "incorrectly dealt with %s when added as a list key (%s != %s)" % (i[0], passed, i[1])
+    assert passed == i[1], \
+        "incorrectly dealt with %s when added as a list key (%s != %s)" % \
+            (i[0], passed, i[1])
 
   for i in [("zebra", True), ("yak", False)]:
     try:
@@ -105,8 +115,8 @@ def main():
     except ValueError:
       wset = False
     assert wset == i[1], \
-      "definition with hybrid typedef across two modules was not set correctly for %s (%s != %s)" \
-        % (i[0], i[1], wset)
+      "definition with hybrid typedef across two modules was not set " + \
+        "correctly for %s (%s != %s)" % (i[0], i[1], wset)
 
   for i in [("IDONE", True), ("IDTWO", True), ("IDTHREE", False)]:
     try:
@@ -115,19 +125,19 @@ def main():
     except ValueError:
       wset = False
     assert wset == i[1], \
-      "definition with a typedef which references an identity was not set correctly for %s (%s != %s)" \
-        % (i[0], i[1], wset)
+      "definition with a typedef which references an identity was not set " + \
+          "correctly for %s (%s != %s)" (i[0], i[1], wset)
 
-  for i in [("aardvark", True), ("bear", True), ("chicken", False), ("quail", True), ("zebra", False)]:
-    #t.container.union_with_union = i[0]
+  for i in [("aardvark", True), ("bear", True), ("chicken", False),
+            ("quail", True), ("zebra", False)]:
     try:
       t.container.union_with_union = i[0]
       wset = True
     except ValueError:
       wset = False
     assert wset == i[1], \
-      "definition which was a union including a typedef was not set correctly for %s (%s != %s)"  \
-        % (i[0], i[1], wset)
+      "definition which was a union including a typedef was not set" + \
+          " correctly for %s (%s != %s)" % (i[0], i[1], wset)
 
   # check that nested typedefs are detected
   passed = None
@@ -137,9 +147,9 @@ def main():
   except ValueError:
     passed = False
 
-  assert passed == True, "scoped leaf was not set correctly (%s - %s != True)" % \
+  assert passed is True, \
+      "scoped leaf was not set correctly (%s - %s != True)" % \
           (t.container.scoped_leaf, passed)
-
 
   if not k:
     os.system("/bin/rm %s/bindings.py" % this_dir)

--- a/tests/uint/run.py
+++ b/tests/uint/run.py
@@ -1,11 +1,13 @@
 #!/usr/bin/env python
 
-import os, sys, getopt
+import os
+import sys
+import getopt
 
-TESTNAME="uint"
+TESTNAME = "uint"
+
 
 # generate bindings in this folder
-
 def main():
   try:
     opts, args = getopt.getopt(sys.argv[1:], "k", ["keepfiles"])
@@ -18,13 +20,16 @@ def main():
     if o in ["-k", "--keepfiles"]:
       k = True
 
-  pyangpath = os.environ.get('PYANGPATH') if os.environ.get('PYANGPATH') is not None else False
-  pyangbindpath = os.environ.get('PYANGBINDPATH') if os.environ.get('PYANGBINDPATH') is not None else False
-  assert not pyangpath == False, "could not find path to pyang"
-  assert not pyangbindpath == False, "could not resolve pyangbind directory"
+  pyangpath = os.environ.get('PYANGPATH') if \
+                os.environ.get('PYANGPATH') is not None else False
+  pyangbindpath = os.environ.get('PYANGBINDPATH') if \
+                os.environ.get('PYANGBINDPATH') is not None else False
+  assert pyangpath is not False, "could not find path to pyang"
+  assert pyangbindpath is not False, "could not resolve pyangbind directory"
 
   this_dir = os.path.dirname(os.path.realpath(__file__))
-  os.system("%s --plugindir %s -f pybind -o %s/bindings.py %s/%s.yang" % (pyangpath, pyangbindpath, this_dir, this_dir, TESTNAME))
+  os.system("%s --plugindir %s -f pybind -o %s/bindings.py %s/%s.yang" %
+              (pyangpath, pyangbindpath, this_dir, this_dir, TESTNAME))
 
   from bindings import uint
 
@@ -33,14 +38,15 @@ def main():
   for name in ["eight", "sixteen", "thirtytwo", "sixtyfour"]:
     for subname in ["", "default", "result", "restricted"]:
       assert hasattr(u.uint_container, "%s%s" % (name, subname)) == True, \
-        "missing %s%s from container" % (name, subname)
+          "missing %s%s from container" % (name, subname)
 
   # tests default and equality
-  for e in [("eight", 2**8-1), ("sixteen", 2**16-1), ("thirtytwo", 2**32-1), ("sixtyfour", 2**64-1)]:
+  for e in [("eight", 2**8 - 1), ("sixteen", 2**16 - 1),
+            ("thirtytwo", 2**32 - 1), ("sixtyfour", 2**64 - 1)]:
     default_v = getattr(u.uint_container, "%sdefault" % e[0])._default
     assert default_v == e[1], \
-      "defaults incorrectly set for %s, expected: %d, got %d" % (e[0], e[1], default_v)
-
+      "defaults incorrectly set for %s, expected: %d, got %d" \
+          % (e[0], e[1], default_v)
 
   u.uint_container.eight = 42
   u.uint_container.sixteen = 42
@@ -54,7 +60,7 @@ def main():
     v = getattr(u.uint_container, i)
     assert v == 42, "incorrectly set %s, expected 42, got %d" % (i, v)
     c = getattr(u.uint_container, "_changed")()
-    assert c == True, "incorrect changed flag for %s" % i
+    assert c is True, "incorrect changed flag for %s" % i
 
   # maybe we need to test math here
 
@@ -63,57 +69,67 @@ def main():
     u.uint_container.eightrestricted = 11
   except ValueError:
     e = True
-  assert e == True, "incorrectly allowed value outside of range for eightrestricted (11)"
+  assert e is True, \
+     "incorrectly allowed value outside of range for eightrestricted (11)"
 
   e = False
   try:
     u.uint_container.eightrestricted = 0
   except ValueError:
     e = True
-  assert e == True, "incorrectly allowed value outside of range for eightrestricted (0)"
+  assert e is True, \
+     "incorrectly allowed value outside of range for eightrestricted (0)"
 
   e = False
   try:
     u.uint_container.sixteenrestricted = 1001
   except ValueError:
     e = True
-  assert e == True, "incorrectly allowed value outside of range for sixteenrestricted (1001)"
+  assert e is True, \
+     "incorrectly allowed value outside of range for sixteenrestricted (1001)"
 
   e = False
   try:
     u.uint_container.sixteenrestricted = 99
   except ValueError:
     e = True
-  assert e == True, "incorrectly allowed value outside of range for sixteenrestricted (99)"
+  assert e is True, \
+     "incorrectly allowed value outside of range for sixteenrestricted (99)"
 
   e = False
   try:
     u.uint_container.thirtytworestricted = 500001
   except ValueError:
     e = True
-  assert e == True, "incorrectly allowed value outside of range for thirtytworestricted (500001)"
+  assert e is True, \
+     "incorrectly allowed value outside of range for thirtytworestricted " + \
+        "(500001)"
 
   e = False
   try:
     u.uint_container.thirtytworestricted = 9999
   except ValueError:
     e = True
-  assert e == True, "incorrectly allowed value outside of range for thirtytworestricted (9999)"
+  assert e is True, \
+     "incorrectly allowed value outside of range for thirtytworestricted " + \
+          "(9999)"
 
   e = False
   try:
     u.uint_container.sixtyfourrestricted = 18446744073709551615
   except ValueError:
     e = True
-  assert e == True, "incorrectly allowed value outside of range for sixtyfourrestricted (18446744073709551615)"
+  assert e is True, \
+     "incorrectly allowed value outside of range for sixtyfourrestricted " + \
+        "(18446744073709551615)"
 
   e = False
   try:
     u.uint_container.sixtyfourrestricted = 799
   except ValueError:
     e = True
-  assert e == True, "incorrectly allowed value outside of range for sixtyfourrestricted (799)"
-
+  assert e is True, \
+     "incorrectly allowed value outside of range for sixtyfourrestricted (799)"
 
   if not k:
     os.system("/bin/rm %s/bindings.py" % this_dir)

--- a/tests/union/run.py
+++ b/tests/union/run.py
@@ -1,11 +1,13 @@
 #!/usr/bin/env python
 
-import os, sys, getopt
+import os
+import sys
+import getopt
 
-TESTNAME="union"
+TESTNAME = "union"
+
 
 # generate bindings in this folder
-
 def main():
   try:
     opts, args = getopt.getopt(sys.argv[1:], "k", ["keepfiles"])
@@ -18,13 +20,16 @@ def main():
     if o in ["-k", "--keepfiles"]:
       k = True
 
-  pyangpath = os.environ.get('PYANGPATH') if os.environ.get('PYANGPATH') is not None else False
-  pyangbindpath = os.environ.get('PYANGBINDPATH') if os.environ.get('PYANGBINDPATH') is not None else False
-  assert not pyangpath == False, "could not find path to pyang"
-  assert not pyangbindpath == False, "could not resolve pyangbind directory"
+  pyangpath = os.environ.get('PYANGPATH') if \
+                os.environ.get('PYANGPATH') is not None else False
+  pyangbindpath = os.environ.get('PYANGBINDPATH') if \
+                os.environ.get('PYANGBINDPATH') is not None else False
+  assert pyangpath is not False, "could not find path to pyang"
+  assert pyangbindpath is not False, "could not resolve pyangbind directory"
 
   this_dir = os.path.dirname(os.path.realpath(__file__))
-  os.system("%s --plugindir %s -f pybind -o %s/bindings.py %s/%s.yang" % (pyangpath, pyangbindpath, this_dir, this_dir, TESTNAME))
+  os.system("%s --plugindir %s -f pybind -o %s/bindings.py %s/%s.yang" %
+              (pyangpath, pyangbindpath, this_dir, this_dir, TESTNAME))
 
   from bindings import union
   import numpy
@@ -40,20 +45,20 @@ def main():
   u.container.u1 = 2
   u.container.u1 += 1
   assert u.container.u1 == 3, \
-  "union with int over string precedence did not result in element acting as int (%s)" % \
-    u.container.u1
+      "union with int over string precedence did not result in element " + \
+          "acting as int (%s)" % u.container.u1
   u.container.u1 = "aStringTest"
   assert u.container.u1 == "aStringTest", \
-  "union of int and string could not be set to a string correctly"
+      "union of int and string could not be set to a string correctly"
   u.container.u1 += "A"
   assert u.container.u1 == "aStringTestA", \
-  "union of int and string when set to string had wrong addition (%s)" \
-    % u.container.u1
+      "union of int and string when set to string had wrong addition (%s)" \
+          % u.container.u1
 
   # u2: precedence of string over int, with a default set
   assert len(u.container.u2) == 0, \
-  "union with a default set was equal to it, rather than a zero length string (%s)" \
-    % len(u.container.u2)
+      "union with a default set was equal to it, rather than a zero " + \
+          "length string (%s)" % len(u.container.u2)
   assert u.container.u2._default == "set from u2", \
     "union with a default did not have the correct value (%s)" \
       % u.container.u2._default
@@ -65,35 +70,36 @@ def main():
 
   # u3: union of int with precendence over string, but default is a string
   assert u.container.u3 == 0, \
-    "union with a default set directly was equal to it rather than an int of value 0 (%s)" \
-      % u.container.u3
+    "union with a default set directly was equal to it rather than an " + \
+        "int of value 0 (%s)" % u.container.u3
   assert u.container.u3._default == "set from u3", \
-    "union with a default that skipped a type did not have the correct value (%s)" \
-      % u.container.u3._default
+    "union with a default that skipped a type did not have " + \
+        "the correct value (%s)" % u.container.u3._default
 
   assert type(u.container.u4._default) == numpy.int8, \
     "union with integer default did not have integer type default (%s)" % \
       type(u.container.u4._default)
 
   assert type(u.container.u6._default) == unicode, \
-    "union with an inherited default from a typedef did not do so correctly (%s)" % \
-      type(u.container.u6._default)
+    "union with an inherited default from a typedef did not " + \
+        "do so correctly (%s)" % type(u.container.u6._default)
 
   u.container.u7 = "hello"
   assert u.container.u7 == "hello", \
-    "leaf with union specified within a typedef not correctly set to string (%s)" % \
-      u.container.u7
+    "leaf with union specified within a typedef not correctly " + \
+        "set to string (%s)" % u.container.u7
   u.container.u7 = 10
   assert u.container.u7 == 10, \
-    "leaf with union specified within a typdef not correctly set to int (%s)" % \
-      u.container.u7
+    "leaf with union specified within a typdef not correctly set " + \
+        "to int (%s)" % u.container.u7
 
   assert u.container.u8._default == 10, \
-    "leaf with default int specified within a union (that was in a typedef) was not set correctly (%s)" % \
-      u.container.u8._default
+    "leaf with default int specified within a union (that was in a" + \
+        " typedef) was not set correctly (%s)" % u.container.u8._default
 
   from bitarray import bitarray
-  for i in [(1, True), ("hello", True), (42.42, True), (True, True), (bitarray(10), False)]:
+  for i in [(1, True), ("hello", True), (42.42, True), (True, True),
+            (bitarray(10), False)]:
     passed = False
     try:
       u.container.u9.append(i[0])
@@ -105,7 +111,7 @@ def main():
         "(%s -> %s != %s)" % (i[0], passed, i[1])
 
   # 10-20, 30-40 or starting with a and b
-  for i in [(15,True), (35,True), ("aardvark", True), ("bear", True),
+  for i in [(15, True), (35, True), ("aardvark", True), ("bear", True),
             (21, False), (42, False), ("cat", False), ("fish", False)]:
     passed = False
     try:
@@ -118,8 +124,8 @@ def main():
       + "correctly validate the value (%s -> %s != %s)" % (i[0], passed, i[1])
 
   assert type(u.container.u11._default) == unicode, \
-    "union of unions that has a string type default not correctly identified (%s)" % \
-      type(u.container.u11._default)
+    "union of unions that has a string type default not correctly " + \
+      "identified (%s)" % type(u.container.u11._default)
 
   if not k:
     os.system("/bin/rm %s/bindings.py" % this_dir)

--- a/tests/xpath/00_pathhelper_base.py
+++ b/tests/xpath/00_pathhelper_base.py
@@ -3,20 +3,29 @@
 import sys
 import os
 
+
 def main():
-  t1_add_retr_object_plain()       # check we can store and retrieve a basic object
-  t2_add_retr_object_with_attr()   # check we can store and retrieve an object with an attribute
-  t3_add_retr_object_hierarchy()   # check we can store and retrieve objects in a hierarchy
-  t4_retr_obj_error()              # check we get the right errors back when an object doesn't exist
+  # check we can store and retrieve a basic object
+  t1_add_retr_object_plain()
+  # check we can store and retrieve an object with an attribute
+  t2_add_retr_object_with_attr()
+  # check we can store and retrieve objects in a hierarchy
+  t3_add_retr_object_hierarchy()
+  # check we get the right errors back when an object doesn't exist
+  t4_retr_obj_error()
+
 
 class TestContainer(object):
   pass
 
+
 class TestObject(object):
   def __init__(self, name):
     self._name = name
+
   def name(self):
     return self._name
+
 
 def t1_add_retr_object_plain(tree=False):
   del_tree = False
@@ -26,14 +35,15 @@ def t1_add_retr_object_plain(tree=False):
   obj_one = TestObject("t1_ObjOneTest")
   tree.register(["obj_one"], obj_one)
   retr_obj = tree.get(["obj_one"])
-  assert len(retr_obj) == 1, ("retrieved path matched the wrong number of objects (%d != 1)"
-    % (len(retr_obj)))
-  assert isinstance(retr_obj[0], TestObject), ("retrieved object was not the " +
-            "correct class")
+  assert len(retr_obj) == 1, ("retrieved path matched the wrong number " +
+        "of objects (%d != 1)" % (len(retr_obj)))
+  assert isinstance(retr_obj[0], TestObject), ("retrieved object was not " +
+            "the correct class")
   assert retr_obj[0].name() == "t1_ObjOneTest", ("retrieved object had an " +
             "invalid name specified (%s != t1_ObjOneTest)" % retr_obj.name())
   if del_tree:
     del tree
+
 
 def t2_add_retr_object_with_attr(tree=False):
   del_tree = False
@@ -43,18 +53,23 @@ def t2_add_retr_object_with_attr(tree=False):
   for p in [["container"], ["container", "deeper"]]:
     tree.register(p, TestObject("container"))
     for q_style in ["'", '"', ""]:
-      for i in range(0,5):
-        tree.register(p+["foo[id=%s%d%s]" % (q_style, i, q_style,)], TestObject("t2_ObjTest%d" % i))
+      for i in range(0, 5):
+        tree.register(p + ["foo[id=%s%d%s]" % (q_style, i, q_style,)],
+              TestObject("t2_ObjTest%d" % i))
       for q_style in ["'", '"', ""]:
-        for j in range(0,5):
-          retr_obj = tree.get("%s/foo[id=%s%d%s]" % ("/"+"/".join(p), q_style, j, q_style,))
-          assert len(retr_obj) == 1, ("retrieved the wrong number of objects (%d != 1)" % len(retr_obj))
-          assert isinstance(retr_obj[0], TestObject), ("retrieved object was not " +
-                    "the correct class")
-          assert retr_obj[0].name() == "t2_ObjTest%d" % j, ("retrieved object had an " +
-                  "invalid name specified (%s != t2_ObjTest%d, q_style=%s)" % (retr_obj.name(), j ,q_style))
+        for j in range(0, 5):
+          retr_obj = tree.get("%s/foo[id=%s%d%s]" %
+                ("/" + "/".join(p), q_style, j, q_style,))
+          assert len(retr_obj) == 1, ("retrieved the wrong number of " +
+                "objects (%d != 1)" % len(retr_obj))
+          assert isinstance(retr_obj[0], TestObject), ("retrieved object " +
+                    "was not the correct class")
+          assert retr_obj[0].name() == "t2_ObjTest%d" % j, \
+              ("retrieved object had an invalid name specified (%s != " +
+                  "t2_ObjTest%d, q_style=%s)" % (retr_obj.name(), j, q_style))
   if del_tree:
     del tree
+
 
 def t3_add_retr_object_hierarchy(tree=False):
   del_tree = False
@@ -63,18 +78,20 @@ def t3_add_retr_object_hierarchy(tree=False):
     tree = YANGPathHelper()
   path = []
   obj = {}
-  for i in range(0,10):
+  for i in range(0, 10):
     path += ["node%d" % i]
     obj[i] = TestObject(i)
     tree.register(path, obj[i])
   path = ""
-  for j in range(0,10):
-    path += "/node%d"% j
+  for j in range(0, 10):
+    path += "/node%d" % j
     retr_obj = tree.get(path)
-    assert len(retr_obj) == 1, ("incorrect number of objects retrieved for %s (%d != 1)" %
-      (path,len(retr_obj)))
+    assert len(retr_obj) == 1, \
+      ("incorrect number of objects retrieved for %s (%d != 1)" %
+          (path, len(retr_obj)))
     assert retr_obj[0].name() == j, ("retrieved object did not " +
               "have a valid name (%s != %s)" % (j, retr_obj.name()))
+
 
 def t4_retr_obj_error(tree=False):
   del_tree = False
@@ -84,18 +101,20 @@ def t4_retr_obj_error(tree=False):
 
   retr = tree.get("/a/non-existant/path")
 
-  assert len(retr) == 0, ("getting a non-existant path returned the wrong number" +
-            "of objects (%d != 0)" % (len(retr)))
+  assert len(retr) == 0, ("getting a non-existant path returned the wrong " +
+            "number of objects (%d != 0)" % (len(retr)))
 
   passed = False
   try:
     tree.register("an-invalid-path-name", TestObject("invalid"))
   except XPathError:
     passed = True
-  assert passed == True, ("setting an invalid path did not throw an XPathError")
+  assert passed is True, ("setting an invalid path did not throw " +
+        "an XPathError")
 
 if __name__ == '__main__':
-  import_path = os.path.realpath(os.path.dirname(os.path.realpath(__file__)) + "/../../lib")
+  import_path = os.path.realpath(os.path.dirname(os.path.realpath(__file__)) +
+                                  "/../../lib")
   sys.path.insert(0, import_path)
   from xpathhelper import YANGPathHelper, XPathError
   main()

--- a/tests/xpath/01-list_leaflist/run.py
+++ b/tests/xpath/01-list_leaflist/run.py
@@ -4,7 +4,8 @@ import sys
 import os
 import getopt
 
-TESTNAME="list-tc01"
+TESTNAME = "list-tc01"
+
 
 def main():
   try:
@@ -18,22 +19,25 @@ def main():
     if o in ["-k", "--keepfiles"]:
       k = True
 
-  pyangpath = os.environ.get('PYANGPATH') if os.environ.get('PYANGPATH') is not None else False
-  pyangbindpath = os.environ.get('PYANGBINDPATH') if os.environ.get('PYANGBINDPATH') is not None else False
-  assert not pyangpath == False, "could not find path to pyang"
-  assert not pyangbindpath == False, "could not resolve pyangbind directory"
+  pyangpath = os.environ.get('PYANGPATH') if os.environ.get('PYANGPATH') \
+      is not None else False
+  pyangbindpath = os.environ.get('PYANGBINDPATH') if \
+      os.environ.get('PYANGBINDPATH') is not None else False
+  assert pyangpath is not False, "could not find path to pyang"
+  assert pyangbindpath is not False, "could not resolve pyangbind directory"
 
   this_dir = os.path.dirname(os.path.realpath(__file__))
-  os.system("%s --plugindir %s -f pybind -o %s/bindings.py --use-xpathhelper %s/%s.yang" % (pyangpath, pyangbindpath, this_dir, this_dir, TESTNAME))
-
+  os.system(("%s --plugindir %s -f pybind -o %s/bindings.py " +
+      "--use-xpathhelper %s/%s.yang") % (pyangpath, pyangbindpath, this_dir,
+          this_dir, TESTNAME))
 
   from bindings import list_tc01 as ytest
 
-  yhelper =  YANGPathHelper()
+  yhelper = YANGPathHelper()
   yobj = ytest(path_helper=yhelper)
 
-  t1_leaflist(yobj,tree=yhelper)
-  t2_list(yobj,tree=yhelper)
+  t1_leaflist(yobj, tree=yhelper)
+  t2_list(yobj, tree=yhelper)
   t3_leaflist_remove(yobj, tree=yhelper)
   t4_list_remove(yobj, tree=yhelper)
   t5_typedef_leaflist_add_del(yobj, tree=yhelper)
@@ -43,7 +47,8 @@ def main():
     os.system("/bin/rm %s/bindings.py" % this_dir)
     os.system("/bin/rm %s/bindings.pyc" % this_dir)
 
-def t1_leaflist(yobj,tree=False):
+
+def t1_leaflist(yobj, tree=False):
   del_tree = False
   if not tree:
     del_tree = True
@@ -59,8 +64,9 @@ def t1_leaflist(yobj,tree=False):
       validref = True
     except ValueError:
       pass
-    assert validref == tc[1], "Reference was incorrectly set for a leaflist" + \
-        " (%s not in %s -> %s != %s)" % (tc[0], str(yobj.container.t1), validref, tc[1])
+    assert validref == tc[1], "Reference was incorrectly set for a" + \
+        " leaflist (%s not in %s -> %s != %s)" % (tc[0],
+            str(yobj.container.t1), validref, tc[1])
 
   for tc in [("flounder", "exists"), ("minnow", "does not exist")]:
     validref = False
@@ -69,13 +75,15 @@ def t1_leaflist(yobj,tree=False):
       validref = True
     except ValueError:
       pass
-    assert validref == True, "Reference was incorrectly set for a leaflist with" + \
-      " require_instance set to false (%s threw error, but it %s)" % tc[1]
+    assert validref is True, "Reference was incorrectly set for a " + \
+      " leaflist with require_instance set to false " + \
+        "(%s threw error, but it %s)" % tc[1]
 
   if del_tree:
     del tree
 
-def t2_list(yobj,tree=False):
+
+def t2_list(yobj, tree=False):
   del_tree = False
   if not tree:
     del_tree = True
@@ -92,10 +100,12 @@ def t2_list(yobj,tree=False):
     except ValueError:
       pass
     assert validref == tc[1], "Reference was incorrectly set for a list" + \
-      " (%s not in %s -> %s != %s)" % (tc[0], yobj.container.t2.keys(), validref, tc[1])
+      " (%s not in %s -> %s != %s)" % (tc[0], yobj.container.t2.keys(),
+            validref, tc[1])
 
   if del_tree:
     del tree
+
 
 def t3_leaflist_remove(yobj, tree=False):
   del_tree = False
@@ -103,15 +113,17 @@ def t3_leaflist_remove(yobj, tree=False):
     del_tree = True
     tree = YANGPathHelper()
 
-  for b in ["oatmeal-stout", "amber-ale", "pale-ale", "pils", "ipa", "session-ipa"]:
+  for b in ["oatmeal-stout", "amber-ale", "pale-ale", "pils",
+            "ipa", "session-ipa"]:
     yobj.container.t3.append(b)
 
   for b in [("session-ipa", 1), ("amber-ale", 1), ("moose-drool", 0)]:
     path = "/container/t3"
     retr = tree.get(path)
     passed = False
-    assert len(retr) == 1, "Looking up a leaf-list element returned multiple elements erroneously (%s -> %d elements (%s))" \
-      % (b[0], len(retr), retr)
+    assert len(retr) == 1, \
+        "Looking up a leaf-list element returned multiple elements " + \
+            "erroneously (%s -> %d elements (%s))" % (b[0], len(retr), retr)
 
     found = False
     try:
@@ -120,7 +132,9 @@ def t3_leaflist_remove(yobj, tree=False):
     except ValueError:
       found = 0
 
-    assert found == b[1], "When retrieving a leaf-list element, a known value was not in the list (%s -> %s (%s))" % (b[0], b[1], retr[0])
+    assert found == b[1], \
+        "When retrieving a leaf-list element, a known value was not in " + \
+            " the list (%s -> %s (%s))" % (b[0], b[1], retr[0])
 
     rem = False
     try:
@@ -128,7 +142,8 @@ def t3_leaflist_remove(yobj, tree=False):
       rem = True
     except ValueError:
       pass
-    assert rem == bool(b[1]), "Removal of a leaflist element did not return expected result (%s -> %s != %s)" % (b[0], rem, bool(b[1]))
+    assert rem == bool(b[1]), "Removal of a leaflist element did not " + \
+        "return expected result (%s -> %s != %s)" % (b[0], rem, bool(b[1]))
     new_retr = tree.get(path)
 
     found = False
@@ -137,10 +152,12 @@ def t3_leaflist_remove(yobj, tree=False):
       found = 1
     except ValueError:
       found = 0
-    assert found == 0, "An element was not correctly removed from the leaf-list (%s -> %s [%s])" % (b[0], path, new_retr[0])
+    assert found == 0, "An element was not correctly removed from the " + \
+        "leaf-list (%s -> %s [%s])" % (b[0], path, new_retr[0])
 
   if del_tree:
     del tree
+
 
 def t4_list_remove(yobj, tree=False):
   del_tree = False
@@ -148,27 +165,33 @@ def t4_list_remove(yobj, tree=False):
     del_tree = True
     tree = YANGPathHelper()
 
-  for b in ["steam", "liberty", "california-lager", "porter", "ipa", "foghorn"]:
+  for b in ["steam", "liberty", "california-lager", "porter", "ipa",
+            "foghorn"]:
     yobj.container.t4.add(b)
 
   for b in [("steam", 1), ("liberty", 1), ("pygmy-owl", 0)]:
     path = "/container/t4[keyval=%s]" % b[0]
     retr = tree.get(path)
-    assert len(retr) == b[1], "Retreive of a list element returned the wrong number of elements (%s -> %d != %d)" % (b[0], len(retr), b[1])
+    assert len(retr) == b[1], \
+        "Retreive of a list element returned the wrong number of elements " + \
+            "(%s -> %d != %d)" % (b[0], len(retr), b[1])
     rem = False
     try:
       yobj.container.t4.delete(b[0])
       rem = True
     except KeyError:
       pass
-    assert rem == bool(b[1]), "Removal of a list element did not return expected result (%s -> %s != %s)" % (b[0], rem, bool(b[1]))
+    assert rem == bool(b[1]), "Removal of a list element did not return " + \
+        "expected result (%s -> %s != %s)" % (b[0], rem, bool(b[1]))
     new_retr = tree.get(path)
-    assert len(new_retr) == 0, "An element was not correctly removed from the list (%s -> len(%s) = %d)" % (b[0], path, len(new_retr))
+    assert len(new_retr) == 0, "An element was not correctly removed from " + \
+        "the list (%s -> len(%s) = %d)" % (b[0], path, len(new_retr))
 
   if del_tree:
     del tree
 
-def t5_typedef_leaflist_add_del(yobj,tree=False):
+
+def t5_typedef_leaflist_add_del(yobj, tree=False):
   del_tree = False
   if not tree:
     del_tree = True
@@ -184,16 +207,20 @@ def t5_typedef_leaflist_add_del(yobj,tree=False):
       validref = True
     except ValueError:
       pass
-    assert validref == tc[1], "Reference was incorrectly set for a leaflist" + \
-        " (%s not in %s -> %s != %s)" % (tc[0], str(yobj.container.t5), validref, tc[1])
+    assert validref == tc[1], "Reference was incorrectly set for a " + \
+        " leaflist (%s not in %s -> %s != %s)" % (tc[0],
+            str(yobj.container.t5), validref, tc[1])
 
   for a in ["vancouver", "burnaby", "surrey", "richmond"]:
     yobj.container.t5.append(a)
 
-  for tc in [("vancouver", True), ("burnaby", True), ("san-francisco", False), ("surrey", True), ("richmond", True)]:
+  for tc in [("vancouver", True), ("burnaby", True), ("san-francisco", False),
+             ("surrey", True), ("richmond", True)]:
     path = "/container/t5"
     retr = tree.get(path)
-    assert (tc[0] in retr[0]) == tc[1], "Retrieve of a leaf-list element did not return expected result (%s->%s %s)" % (tc[0], tc[1], (retr[0]))
+    assert (tc[0] in retr[0]) == tc[1], "Retrieve of a leaf-list element " + \
+        "did not return expected result (%s->%s %s)" % (tc[0], tc[1],
+              (retr[0]))
     rem = False
     try:
       retr[0].remove(tc[0])
@@ -201,26 +228,33 @@ def t5_typedef_leaflist_add_del(yobj,tree=False):
     except ValueError:
       pass
     new_retr = tree.get(path)
-    assert rem == bool(tc[1]), "An element was not correctly removed from a leaf-list (%s -> len(%s) = %d)" % (tc[0], path, len(new_retr))
+    assert rem == bool(tc[1]), "An element was not correctly removed from " + \
+        "a leaf-list (%s -> len(%s) = %d)" % (tc[0], path, len(new_retr))
 
-
-  for tc in [("gatineau", True), ("laval", True), ("new-york-city", False), ("quebec-city", True)]:
+  for tc in [("gatineau", True), ("laval", True), ("new-york-city", False),
+             ("quebec-city", True)]:
     path = "/container/t5"
     retr = tree.get(path)
-    assert (tc[0] in retr[0]) == tc[1], "Retrieve of a leaf-list element did not return expected result (%s->%s %s)" % (tc[0], tc[1], (retr[0]))
+    assert (tc[0] in retr[0]) == tc[1], "Retrieve of a leaf-list element " + \
+        "did not return expected result (%s->%s %s)" % (tc[0], tc[1],
+            (retr[0]))
     popped_obj = retr[0].pop()
     if popped_obj == tc[0]:
       expected_obj = True
     else:
       expected_obj = False
-    assert expected_obj == bool(tc[1]), "Popped object was not the object that was expected (%s != %s)" % (tc[0],popped_obj)
+    assert expected_obj == bool(tc[1]), "Popped object was not the " + \
+        "object that was expected (%s != %s)" % (tc[0], popped_obj)
     new_retr = tree.get(path)
-    assert (tc[0] in new_retr[0]) == False, "Retrieve of a leaf-list element did not return expected result (%s->%s %s)" % (tc[0], tc[1], (new_retr[0]))
+    assert (tc[0] in new_retr[0]) == False, "Retrieve of a leaf-list " + \
+        "element did not return expected result (%s->%s %s)" % (tc[0], tc[1],
+              (new_retr[0]))
 
   if del_tree:
     del tree
 
-def t6_typedef_list_add(yobj,tree=False):
+
+def t6_typedef_list_add(yobj, tree=False):
   del_tree = False
   if not tree:
     del_tree = True
@@ -237,12 +271,14 @@ def t6_typedef_list_add(yobj,tree=False):
     except ValueError:
       pass
     assert validref == tc[1], "Reference was incorrectly set for a list" + \
-      " (%s not in %s -> %s != %s)" % (tc[0], yobj.container.t6.keys(), validref, tc[1])
+      " (%s not in %s -> %s != %s)" % (tc[0], yobj.container.t6.keys(),
+            validref, tc[1])
 
   if del_tree:
     del tree
 
-def t7_leaflist_of_leafrefs(yobj,tree=False):
+
+def t7_leaflist_of_leafrefs(yobj, tree=False):
   del_tree = False
   if not tree:
     del_tree = True
@@ -261,10 +297,12 @@ def t7_leaflist_of_leafrefs(yobj,tree=False):
     except:
       pass
 
-    assert passed == b[1], "A reference to a leaf-list of leafrefs was not correctly set (%s -> %s, expected %s)" % (b[0], passed, b[1])
+    assert passed == b[1], "A reference to a leaf-list of leafrefs " + \
+        "was not correctly set (%s -> %s, expected %s)" % (b[0], passed, b[1])
 
 if __name__ == '__main__':
-  import_path = os.path.realpath(os.path.dirname(os.path.realpath(__file__)) + "/../../../")
+  import_path = os.path.realpath(os.path.dirname(os.path.realpath(__file__)) +
+       "/../../../")
   sys.path.insert(0, import_path)
   from lib.xpathhelper import YANGPathHelper, XPathError
   main()

--- a/tests/xpath/02-static_ptr/run.py
+++ b/tests/xpath/02-static_ptr/run.py
@@ -4,7 +4,8 @@ import sys
 import os
 import getopt
 
-TESTNAME="ptr-tc02"
+TESTNAME = "ptr-tc02"
+
 
 def main():
   try:
@@ -18,18 +19,21 @@ def main():
     if o in ["-k", "--keepfiles"]:
       k = True
 
-  pyangpath = os.environ.get('PYANGPATH') if os.environ.get('PYANGPATH') is not None else False
-  pyangbindpath = os.environ.get('PYANGBINDPATH') if os.environ.get('PYANGBINDPATH') is not None else False
-  assert not pyangpath == False, "could not find path to pyang"
-  assert not pyangbindpath == False, "could not resolve pyangbind directory"
+  pyangpath = os.environ.get('PYANGPATH') if os.environ.get('PYANGPATH') \
+      is not None else False
+  pyangbindpath = os.environ.get('PYANGBINDPATH') if \
+      os.environ.get('PYANGBINDPATH') is not None else False
+  assert pyangpath is not False, "could not find path to pyang"
+  assert pyangbindpath is not False, "could not resolve pyangbind directory"
 
   this_dir = os.path.dirname(os.path.realpath(__file__))
-  os.system("%s --plugindir %s -f pybind -o %s/bindings.py --use-xpathhelper %s/%s.yang" % (pyangpath, pyangbindpath, this_dir, this_dir, TESTNAME))
-
+  os.system(("%s --plugindir %s -f pybind -o %s/bindings.py " +
+      "--use-xpathhelper %s/%s.yang") % (pyangpath, pyangbindpath, this_dir,
+          this_dir, TESTNAME))
 
   from bindings import ptr_tc02 as ytest
 
-  yhelper =  YANGPathHelper()
+  yhelper = YANGPathHelper()
   yobj = ytest(path_helper=yhelper)
 
   t1_listkey(yobj, tree=yhelper)
@@ -38,20 +42,20 @@ def main():
     os.system("/bin/rm %s/bindings.py" % this_dir)
     os.system("/bin/rm %s/bindings.pyc" % this_dir)
 
-def t1_listkey(yobj,tree=False):
+
+def t1_listkey(yobj, tree=False):
   del_tree = False
   if not tree:
     del_tree = True
     tree = YANGPathHelper()
 
-
-  for x in range(0,100):
+  for x in range(0, 100):
     yobj.container.t1a.add("x%s" % x)
 
-  for x in range(0,100):
+  for x in range(0, 100):
     assert yobj.container.t1a["x%s" % x].t1c.t1d == "x%s" % x, \
-      "list key was not set correctly when acting as a pointer (%s != 'test')" % \
-        (yobj.container.t1a["x%s" % x].t1c.t1d)
+        "list key was not set correctly when acting as a pointer " + \
+        "(%s != 'test')" % (yobj.container.t1a["x%s" % x].t1c.t1d)
     assert str(yobj.container.t1a["x%s" % x].t1b) == "x%s" % x, \
       "list key pointer was not read correctly (value is %s)" % \
         yobj.container.t1a["x%s" % x].t1b
@@ -61,7 +65,8 @@ def t1_listkey(yobj,tree=False):
 
 
 if __name__ == '__main__':
-  import_path = os.path.realpath(os.path.dirname(os.path.realpath(__file__)) + "/../../..")
+  import_path = os.path.realpath(os.path.dirname(os.path.realpath(__file__)) +
+                    "/../../..")
   sys.path.insert(0, import_path)
   from lib.xpathhelper import YANGPathHelper, XPathError
   main()

--- a/tests/xpath/03-current/run.py
+++ b/tests/xpath/03-current/run.py
@@ -4,7 +4,8 @@ import sys
 import os
 import getopt
 
-TESTNAME="current-tc03"
+TESTNAME = "current-tc03"
+
 
 def main():
   try:
@@ -18,13 +19,17 @@ def main():
     if o in ["-k", "--keepfiles"]:
       k = True
 
-  pyangpath = os.environ.get('PYANGPATH') if os.environ.get('PYANGPATH') is not None else False
-  pyangbindpath = os.environ.get('PYANGBINDPATH') if os.environ.get('PYANGBINDPATH') is not None else False
-  assert not pyangpath == False, "could not find path to pyang"
-  assert not pyangbindpath == False, "could not resolve pyangbind directory"
+  pyangpath = os.environ.get('PYANGPATH') if os.environ.get('PYANGPATH') \
+      is not None else False
+  pyangbindpath = os.environ.get('PYANGBINDPATH') if \
+      os.environ.get('PYANGBINDPATH') is not None else False
+  assert pyangpath is not False, "could not find path to pyang"
+  assert pyangbindpath is not False, "could not resolve pyangbind directory"
 
   this_dir = os.path.dirname(os.path.realpath(__file__))
-  os.system("%s --plugindir %s -f pybind -o %s/bindings.py --use-xpathhelper %s/%s.yang" % (pyangpath, pyangbindpath, this_dir, this_dir, TESTNAME))
+  os.system(("%s --plugindir %s -f pybind -o %s/bindings.py " +
+      "--use-xpathhelper %s/%s.yang") % (pyangpath, pyangbindpath, this_dir,
+          this_dir, TESTNAME))
 
   from bindings import current_tc03
   yhelper = YANGPathHelper()
@@ -36,13 +41,14 @@ def main():
     os.system("/bin/rm %s/bindings.py" % this_dir)
     os.system("/bin/rm %s/bindings.pyc" % this_dir)
 
+
 def t1_currentref(yobj, tree=False):
   del_tree = False
   if not tree:
     del_tree = True
     tree = YANGPathHelper()
 
-  for i in [(1,2,), (3,4), (5,6)]:
+  for i in [(1, 2), (3, 4), (5, 6)]:
     yobj.src_list.add("%s %s" % i)
 
   yobj.referencing_list.add(1)
@@ -53,17 +59,20 @@ def t1_currentref(yobj, tree=False):
   except ValueError:
     e = True
 
-  assert e == False, "incorrectly rejected valid reference"
+  assert e is False, "incorrectly rejected valid reference"
 
-  assert yobj.src_list["1 2"].referenced == "1", "referenced value was incorrectly set"
-  assert yobj.src_list["1 2"].value == "2", "referenced value was incorrectly set"
+  assert yobj.src_list["1 2"].referenced == "1", \
+      "referenced value was incorrectly set"
+  assert yobj.src_list["1 2"].value == "2", \
+      "referenced value was incorrectly set"
 
   if del_tree:
     del yhelper
 
 
 if __name__ == '__main__':
-  import_path = os.path.realpath(os.path.dirname(os.path.realpath(__file__)) + "/../../..")
+  import_path = os.path.realpath(os.path.dirname(os.path.realpath(__file__)) +
+                  "/../../..")
   sys.path.insert(0, import_path)
   from lib.xpathhelper import YANGPathHelper, XPathError
   main()


### PR DESCRIPTION
@vnitinv 

I propose that we merge this pull-req to support general PEP8 compliance. Commit comment below shows what is not complied with - hopefully this is something that you can set in your editor to ignore (Sublime Text 3, with SublimeLint and the PEP8 module has this ability). Comments welcome.

	* As per Nitin's suggestion -- code is now mostly compliant with
	  the guidelines in PEP8. Exceptions:
	  	*	Indentation is 2 spaces, not 4 (ignore: E111, E114)
	  	* 'Natural' indentation is used for continuation (Ignore: E127,
	  		 E128)