### PR TITLE
Issue when creating a list item, when a named set is used, and only one key value is supplied which doesn't contain a space

### DIFF
--- a/pyangbind/lib/yangtypes.py
+++ b/pyangbind/lib/yangtypes.py
@@ -571,7 +571,7 @@ def YANGListType(*args, **kwargs):
               raise KeyError("YANGList key must contain all key elements (%s)"
                                 % (self._keyval.split(" ")))
 
-          elif " " in self._keyval and named_set:
+          elif named_set:
             k = kwargs.pop("_python_key", None)
             keydict = copy.copy(kwargs)
           else:


### PR DESCRIPTION
Hi Rob,

Minor bug error when creating a keyed list item with a named key (key=key value) where a single key value is used, and no space character is contained in the Key Value supplied


The following worked: 

```
pybind_obj = pybindobj().somelist.add("somevalue")
pybind_obj = pybindobj().somelist.add(keyfield="some value")
pybind_obj = pybindobj().somelist.add(keyfield1="somevalue", keyfield2="somevalue")
```

The following didn't work (no space, single key, named key):

`pybind_obj = pybindobj().somelist.add(keyfield="somevalue")`

Cheers,
Mark