### PR TITLE
Issue with Min values for Integer types with a Restriction/Range specified

### DIFF
--- a/pyangbind/plugin/pybind.py
+++ b/pyangbind/plugin/pybind.py
@@ -138,24 +138,24 @@ class_map = {
         "pytype": YANGBool
     },
     'int8': {
-        "native_type": "RestrictedClassType(base_type=int, restriction_dict={'range': ['-127..127']}, int_size=8)",
+        "native_type": "RestrictedClassType(base_type=int, restriction_dict={'range': ['-128..127']}, int_size=8)",
         "base_type": True,
-        "pytype": RestrictedClassType(base_type=int, restriction_dict={'range': ['-127..127']}, int_size=8)
+        "pytype": RestrictedClassType(base_type=int, restriction_dict={'range': ['-128..127']}, int_size=8)
     },
     'int16': {
-        "native_type": "RestrictedClassType(base_type=int, restriction_dict={'range': ['-32767..32767']}, int_size=16)",
+        "native_type": "RestrictedClassType(base_type=int, restriction_dict={'range': ['-32768..32767']}, int_size=16)",
         "base_type": True,
-        "pytype": RestrictedClassType(base_type=int, restriction_dict={'range': ['-32767..32767']}, int_size=16)
+        "pytype": RestrictedClassType(base_type=int, restriction_dict={'range': ['-32768..32767']}, int_size=16)
     },
     'int32': {
-        "native_type": "RestrictedClassType(base_type=long, restriction_dict={'range': ['-2147483647..2147483647']}, int_size=32)",
+        "native_type": "RestrictedClassType(base_type=long, restriction_dict={'range': ['-2147483648..2147483647']}, int_size=32)",
         "base_type": True,
-        "pytype": RestrictedClassType(base_type=long, restriction_dict={'range': ['-2147483647..2147483647']}, int_size=32)
+        "pytype": RestrictedClassType(base_type=long, restriction_dict={'range': ['-2147483648..2147483647']}, int_size=32)
     },
     'int64': {
-        "native_type": "RestrictedClassType(base_type=long, restriction_dict={'range': ['-9223372036854775807..9223372036854775807']}, int_size=64)",
+        "native_type": "RestrictedClassType(base_type=long, restriction_dict={'range': ['-9223372036854775808..9223372036854775807']}, int_size=64)",
         "base_type": True,
-        "pytype": RestrictedClassType(base_type=long, restriction_dict={'range': ['-9223372036854775807..9223372036854775807']}, int_size=64)
+        "pytype": RestrictedClassType(base_type=long, restriction_dict={'range': ['-9223372036854775808..9223372036854775807']}, int_size=64)
     },
 }
 

--- a/tests/int/int.yang
+++ b/tests/int/int.yang
@@ -130,6 +130,18 @@ module int {
             }
         }
 
+        leaf restricted-ueight-min {
+            type int8 {
+                range "-128..max";
+            }
+        }
+
+        leaf restricted-ueight-min-alias {
+            type int8 {
+        //        range "min..max";
+            }
+        }
+
         leaf complex-range {
             type int8 {
                 range "0..10|15..20";

--- a/tests/int/run.py
+++ b/tests/int/run.py
@@ -170,6 +170,28 @@ def main():
         "restricted range using max was not set correctly (%d -> %s != %s)" % \
             (i[0], passed, i[1])
 
+  for i in [(0, True), (10, True), (-128, True), (-300, False)]:
+    passed = False
+    try:
+      u.int_container.restricted_ueight_min = i[0]
+      passed = True
+    except ValueError:
+      pass
+    assert passed == i[1], \
+        "restricted range using min was not set correctly (%d -> %s != %s)" % \
+            (i[0], passed, i[1])
+
+  for i in [(0, True), (10, True), (-128, True), (-300, False)]:
+    passed = False
+    try:
+      u.int_container.restricted_ueight_min_alias = i[0]
+      passed = True
+    except ValueError:
+      pass
+    assert passed == i[1], \
+        "restricted range using min alias was not set correctly (%d -> %s != %s)" % \
+            (i[0], passed, i[1])
+
   for i in [(0, True), (13, False), (-20, False), (5, True), (16, True)]:
     passed = False
     try:


### PR DESCRIPTION
Hi Rob,

As you can see from the commit comments:

> Corrected values for the ranges of signed Integer types to include the correct minimum value
> Added test case for minimum value of an integer with a restriction/range
> Added test case for 'min' alias value which is currently broken

I've included an example of a still broken case where if you specify a restriction that uses the 'min' keyword, it does not work. It's currently commented out, as it breaks the test.

```
leaf restricted-ueight-min-alias {
    type int8 {
        range "min..max";
    }
}
```
