### PR TITLE
Y2c script

### DIFF
--- a/scripts/y2c
+++ b/scripts/y2c
@@ -7,13 +7,14 @@
 trap "exit 1;" SIGINT SIGTERM
 
 read -r -d "" HELP << "EOF"
-usage: y2c [-i INPUT_DIRECTORY] [-o OUTPUT_DIRECTORY]
+usage: y2c [-i INPUT_DIRECTORY] [-o OUTPUT_DIRECTORY] [-p PATH]
 
 Generates Python classes from YANG models.
 
 optional arguments:
   -i INPUT_DIR          Read YANG models from this directory root.
   -o OUTPUT_DIR         Write Python classes to this directory root.
+  -p PATH               Append PATH to the pyang -p option.
 EOF
 
 INPUT_DIR="models"
@@ -31,7 +32,7 @@ if [ -z "$PYBINDPLUGIN" ]; then
     exit 1
 fi
 
-while getopts ":hi:o:" opt; do
+while getopts ":hi:o:p:" opt; do
     case $opt in
         h)
             echo "$HELP" >&2
@@ -42,6 +43,9 @@ while getopts ":hi:o:" opt; do
             ;;
         o)
             OUTPUT_DIR=$OPTARG
+            ;;
+        p)
+            PYANG_PATH=$OPTARG
             ;;
         \?)
             echo "Invalid option: -$OPTARG" >&2
@@ -79,7 +83,7 @@ for YANG_SRC_FILE in $YANG_SRC_FILES; do
 
     echo "*** Processing $YANG_SRC_FILE ***"
 
-    $PYANG --plugindir $PYBINDPLUGIN -p $INPUT_DIR -f pybind --split-class-dir $OUTPUT_DIR/$CLASS_DIR $YANG_SRC_FILE
+    $PYANG --plugindir $PYBINDPLUGIN -p $INPUT_DIR:$PYANG_PATH -f pybind --split-class-dir $OUTPUT_DIR/$CLASS_DIR $YANG_SRC_FILE
 
     if [ $? != 0 ]; then
         echo "*** PROBLEM WITH $YANG_SRC_FILE ***"

--- a/scripts/y2c
+++ b/scripts/y2c
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+
+#
+# Author: Cyrus Durgin <cyrusd@gmail.com>
+#
+
+trap "exit 1;" SIGINT SIGTERM
+
+read -r -d "" HELP << "EOF"
+usage: y2c [-i INPUT_DIRECTORY] [-o OUTPUT_DIRECTORY]
+
+Generates Python classes from YANG models.
+
+optional arguments:
+  -i INPUT_DIR          Read YANG models from this directory root.
+  -o OUTPUT_DIR         Write Python classes to this directory root.
+EOF
+
+INPUT_DIR="models"
+OUTPUT_DIR="classes"
+
+PYANG=`which pyang`
+if [ -z "$PYANG" ]; then
+    echo "Cannot locate pyang; install with pip." >&2
+    exit 1
+fi
+
+PYBINDPLUGIN=`/usr/bin/env python -c 'import pyangbind; import os; print "%s/plugin" % os.path.dirname(pyangbind.__file__)'`
+if [ -z "$PYBINDPLUGIN" ]; then
+    echo "Cannot locate pyangbind; install with pip." >&2
+    exit 1
+fi
+
+while getopts ":hi:o:" opt; do
+    case $opt in
+        h)
+            echo "$HELP" >&2
+            exit 0
+            ;;
+        i)
+            INPUT_DIR=$OPTARG
+            ;;
+        o)
+            OUTPUT_DIR=$OPTARG
+            ;;
+        \?)
+            echo "Invalid option: -$OPTARG" >&2
+            echo >&2
+            echo "$HELP" >&2
+            exit 1
+            ;;
+        :)
+            echo "Option -$OPTARG requires an argument." >&2
+            echo >&2
+            echo "$HELP" >&2
+            exit 1
+            ;;
+    esac
+done
+
+YANG_SRC_FILES=$(find $INPUT_DIR -type f -a -name "*.yang" 2> /dev/null)
+
+if [ $? -gt 0 ]; then
+    echo "Cannot find yang models in '$INPUT_DIR'." >&2
+    echo >&2
+    echo "$HELP" >&2
+    exit 1
+fi
+
+ERRORS=0
+SRC_FILES=0
+SECONDS=0
+ERROR_FILES=()
+
+for YANG_SRC_FILE in $YANG_SRC_FILES; do
+    ((SRC_FILES++))
+
+    CLASS_DIR=$(echo $(dirname $(realpath $YANG_SRC_FILE)) | sed "s#$PWD/$INPUT_DIR##" | sed "s#^/##")
+
+    echo "*** Processing $YANG_SRC_FILE ***"
+
+    $PYANG --plugindir $PYBINDPLUGIN -p $INPUT_DIR -f pybind --split-class-dir $OUTPUT_DIR/$CLASS_DIR $YANG_SRC_FILE
+
+    if [ $? != 0 ]; then
+        echo "*** PROBLEM WITH $YANG_SRC_FILE ***"
+        ((ERRORS++))
+        ERROR_FILES+=($YANG_SRC_FILE)
+    else
+        echo "*** Finished: output $OUTPUT_DIR/$CLASS_DIR ***"
+    fi
+
+    echo
+done
+
+DURATION=$SECONDS
+
+echo "*** Processed $SRC_FILES source files with $ERRORS errors in $((DURATION / 60)) minutes and $((DURATION % 60))" \
+     "seconds ***"
+
+if [ $ERRORS -gt 0 ]; then
+    echo "*** Source files with errors:"
+    for ERROR_FILE in ${ERROR_FILES[@]}; do
+        echo "    $ERROR_FILE"
+    done
+    exit 1
+fi
+
+exit 0
+

--- a/setup.py
+++ b/setup.py
@@ -45,4 +45,5 @@ setup(
     packages=find_packages(exclude=['lib']),
     install_requires=inst_reqs,
     zip_safe = False,
+    scripts = ['scripts/y2c']
 )


### PR DESCRIPTION
Hi Rob,

Here's that script; I modified it slightly to use the better `--split-class-dir` option, while retaining the overall directory structure of the source files; using the openconfig models as an example:

```
(pyangbind) [cyrusd@cyrusd public (master)]$ y2c -i release/models -o /tmp/models
*** Processing release/models/local-routing/openconfig-local-routing.yang ***
*** Finished: output /tmp/models/local-routing ***

*** Processing release/models/policy/openconfig-policy-types.yang ***
*** Finished: output /tmp/models/policy ***

*** Processing release/models/policy/openconfig-routing-policy.yang ***
*** Finished: output /tmp/models/policy ***
[ LOTS MORE OUTPUT ]
*** Processed 37 source files with 0 errors in 0 minutes and 42 seconds ***
(pyangbind) [cyrusd@cyrusd public (master)]$ ls /tmp/models/
bgp      lacp       network-instance   policy  telemetry
__init__.py  local-routing  optical-transport  rib     vlan
interfaces   mpls       platform           rpc
(pyangbind) [cyrusd@cyrusd public (master)]$ tree /tmp/models/local-routing/
/tmp/models/local-routing/
├── __init__.py
└── local_routes
    ├── __init__.py
    ├── local_aggregates
    │   ├── aggregate
    │   │   ├── config
    │   │   │   └── __init__.py
    │   │   ├── __init__.py
    │   │   └── state
    │   │       └── __init__.py
    │   └── __init__.py
    └── static_routes
        ├── __init__.py
        └── static
            ├── config
            │   └── __init__.py
            ├── __init__.py
            └── state
                └── __init__.py

9 directories, 10 files
```
