### PR TITLE
Add ability to ignore unknown keys in a JSON deserialisation

### DIFF
--- a/pyangbind/lib/serialise.py
+++ b/pyangbind/lib/serialise.py
@@ -233,7 +233,7 @@ class pybindJSONDecoder(object):
       if child is None and skip_unknown is False:
         raise AttributeError("JSON object contained a key that" +
                               "did not exist (%s)" % (key))
-      elif skip_unknown:
+      elif child is None and skip_unknown:
         # skip unknown elements if we are asked to by the user`
         continue
       chobj = child()
@@ -251,9 +251,12 @@ class pybindJSONDecoder(object):
         # we need to add each key to the list and then skip a level in the
         # JSON hierarchy
         list_obj = getattr(obj, safe_name(key), None)
-        if list_obj is None:
+        if list_obj is None and skip_unknown is False:
           raise pybindJSONDecodeError("Could not load list object " +
                     "with name %s" % key)
+        if list_obj is None and skip_unknown is not False:
+          continue
+
         ordered_list = getattr(list_obj, "_ordered", None)
         if ordered_list:
           # Put keys in order:

--- a/tests/serialise/ietf-json-deserialise/json/nonexistkey.json
+++ b/tests/serialise/ietf-json-deserialise/json/nonexistkey.json
@@ -1,0 +1,16 @@
+{
+  "skey": [
+    {
+      "leaf-one": "one",
+      "non-exist": true
+    },
+    {
+      "leaf-one": "two",
+      "non-exist": false
+    },
+    {
+      "leaf-one": "three",
+      "non-exist": true
+    }
+  ]
+}

--- a/tests/serialise/ietf-json-deserialise/run.py
+++ b/tests/serialise/ietf-json-deserialise/run.py
@@ -130,6 +130,20 @@ def main():
   assert nobj.get(filter=True) == expected_get, "Deserialisation of " + \
     "complete object not as expected"
 
+  pth = os.path.join(this_dir, "json", "nonexistkey.json")
+  for i in [True, False]:
+    nobj = None
+    success = True
+    try:
+      nobj = pybindJSONDecoder.load_ietf_json(json.load(open(pth, 'r')),
+        bindings, "ietf_json_deserialise", skip_unknown=i)
+    except AttributeError:
+      success = False
+
+    assert success is i, "Skipping keys that did not exist was not" + \
+      " successfully handled"
+
+
   if not k:
     os.system("/bin/rm %s/bindings.py" % this_dir)
     os.system("/bin/rm %s/bindings.pyc" % this_dir)

--- a/tests/serialise/json-deserialise/json/nonexist.json
+++ b/tests/serialise/json-deserialise/json/nonexist.json
@@ -1,0 +1,18 @@
+{
+    "load-list": {
+        "1": {
+            "index": 1,
+            "value": "one",
+            "no": "thisdoesnotexist"
+        },
+        "2": {
+            "index": 2,
+            "value": "two",
+            "fourtytwo": 42
+        },
+        "3": {
+            "index": 3,
+            "value": "three"
+        }
+    }
+}

--- a/tests/serialise/json-deserialise/run.py
+++ b/tests/serialise/json-deserialise/run.py
@@ -5,6 +5,7 @@ import sys
 import getopt
 import json
 import pyangbind.lib.serialise as pbS
+from pyangbind.lib.serialise import pybindJSONDecoder
 import pyangbind.lib.pybindJSON as pbJ
 from bitarray import bitarray
 from decimal import *
@@ -128,6 +129,19 @@ def main():
                 bindings, "json_deserialise", path_helper=y)
   assert js.ordered.keys() == ["one", "two"], \
         "Did not correctly follow ordering in JSON file"
+
+  pth = os.path.join(this_dir, "json", "nonexist.json")
+  for i in [True, False]:
+    nobj = None
+    success = True
+    try:
+      nobj = pybindJSONDecoder.load_ietf_json(json.load(open(pth, 'r')),
+        bindings, "json_deserialise", skip_unknown=i)
+    except AttributeError:
+      success = False
+
+    assert success is i, "Skipping keys that did not exist was not" + \
+      " successfully handled"
 
   if not k:
     os.system("/bin/rm %s/bindings.py" % this_dir)


### PR DESCRIPTION
During deserialisation, it is sometimes advantageous to ignore keys that are unknown by the bindings, this merge adds that ability.