### PR TITLE
Adding requirements.txt to source dist file

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
 include pyangbind/plugin/*.py
 include *.md
+include *.txt
 include LICENSE


### PR DESCRIPTION
`setup.py` references `requirements.txt` but it is not included in source tar ball. Pip install from source tar ball fails due to this.