### PR TITLE
Fixed UTs that use unittest.main not supporting the -k argument

### DIFF
--- a/tests/integration/openconfig-interfaces/run.py
+++ b/tests/integration/openconfig-interfaces/run.py
@@ -125,7 +125,10 @@ class PyangbindOCIntf(unittest.TestCase):
 
 if __name__ == '__main__':
   setup_test()
-  T = unittest.main(exit=False)
+  args = sys.argv
+  if '-k' in args:
+    args.remove('-k')
+  T = unittest.main(exit=False, argv=args)
   if len(T.result.errors) or len(T.result.failures):
     exitcode = 127
   else:

--- a/tests/misc/run.py
+++ b/tests/misc/run.py
@@ -102,7 +102,10 @@ class PyangbindMiscTests(unittest.TestCase):
 
 if __name__ == '__main__':
   setup_test()
-  T = unittest.main(exit=False)
+  args = sys.argv
+  if '-k' in args:
+    args.remove('-k')
+  T = unittest.main(exit=False, argv=args)
   if len(T.result.errors) or len(T.result.failures):
     exitcode = 127
   else:

--- a/tests/presence/run.py
+++ b/tests/presence/run.py
@@ -159,7 +159,10 @@ class PyangbindPresenceTests(unittest.TestCase):
 
 if __name__ == '__main__':
   setup_test()
-  T = unittest.main(exit=False)
+  args = sys.argv
+  if '-k' in args:
+    args.remove('-k')
+  T = unittest.main(exit=False, argv=args)
   if len(T.result.errors) or len(T.result.failures):
     exitcode = 127
   else:

--- a/tests/submodules/run.py
+++ b/tests/submodules/run.py
@@ -84,7 +84,10 @@ class PyangbindSubmoduleTests(unittest.TestCase):
 
 if __name__ == '__main__':
   setup_test()
-  T = unittest.main(exit=False)
+  args = sys.argv
+  if '-k' in args:
+    args.remove('-k')
+  T = unittest.main(exit=False, argv=args)
   if len(T.result.errors) or len(T.result.failures):
     exitcode = 127
   else:


### PR DESCRIPTION
This fixes #99. I'm pulling out the `-k` argument and passing everything else on to `unittest`, which is the simplest fix. Perhaps it would be better to pass no args by default and add specific arguments that are supported, in order to make the command-line options more consistent between the different `run.py` scripts, though I don't think this is a big deal right now.