### PR TITLE
Resolve UTs not correctly keeping generated files

### DIFF
--- a/tests/integration/openconfig-interfaces/run.py
+++ b/tests/integration/openconfig-interfaces/run.py
@@ -15,7 +15,6 @@ TESTNAME = "openconfig-interfaces"
 
 # generate bindings in this folder
 def setup_test():
-  global k
   global this_dir
   global del_dirs
 
@@ -24,11 +23,6 @@ def setup_test():
   except getopt.GetoptError as e:
     print str(e)
     sys.exit(127)
-
-  k = False
-  for o, a in opts:
-    if o in ["-k", "--keepfiles"]:
-      k = True
 
   pythonpath = os.environ.get("PATH_TO_PYBIND_TEST_PYTHON") if \
                 os.environ.get('PATH_TO_PYBIND_TEST_PYTHON') is not None \
@@ -97,19 +91,16 @@ def setup_test():
   os.system(cmd)
 
 def teardown_test():
-  global k
   global this_dir
   global del_dirs
-
-  if not k:
-    del_dirs.append(os.path.join(this_dir, "ocbind"))
-    for dirname in del_dirs:
-      for root, dirs, files in os.walk(os.path.join(dirname), topdown=False):
-        for name in files:
-          os.remove(os.path.join(root, name))
-        for name in dirs:
-          os.rmdir(os.path.join(root, name))
-      os.rmdir(dirname)
+  del_dirs.append(os.path.join(this_dir, "ocbind"))
+  for dirname in del_dirs:
+    for root, dirs, files in os.walk(os.path.join(dirname), topdown=False):
+      for name in files:
+        os.remove(os.path.join(root, name))
+      for name in dirs:
+        os.rmdir(os.path.join(root, name))
+    os.rmdir(dirname)
 
 class PyangbindOCIntf(unittest.TestCase): 
   def __init__(self, *args, **kwargs):
@@ -124,11 +115,17 @@ class PyangbindOCIntf(unittest.TestCase):
     self.assertNotEqual(len(i0.config.type._restriction_dict), 0)
 
 if __name__ == '__main__':
+  keepfiles = False
+  args = sys.argv
+  if '-k' in args:
+    keepfiles = True
+    args.remove('-k')
   setup_test()
-  T = unittest.main(exit=False)
+  T = unittest.main(exit=False, argv=args)
   if len(T.result.errors) or len(T.result.failures):
     exitcode = 127
   else:
     exitcode = 0
-  teardown_test()
+  if keepfiles is False:
+    teardown_test()
   sys.exit(exitcode)

--- a/tests/misc/run.py
+++ b/tests/misc/run.py
@@ -12,8 +12,6 @@ import json
 
 TESTNAME = "misc"
 
-k = False
-
 # generate bindings in this folder
 def setup_test():
   try:
@@ -21,12 +19,7 @@ def setup_test():
   except getopt.GetoptError as e:
     sys.exit(127)
 
-  global k
   global this_dir
-
-  for o, a in opts:
-    if o in ["-k", "--keepfiles"]:
-      k = True
 
   pythonpath = os.environ.get("PATH_TO_PYBIND_TEST_PYTHON") if \
                 os.environ.get('PATH_TO_PYBIND_TEST_PYTHON') is not None \
@@ -51,11 +44,9 @@ def setup_test():
   os.system(cmd)
 
 def teardown_test():
-  global k
   global this_dir
 
-  if not k:
-    os.system("/bin/rm -rf %s/bindings" % this_dir)
+  os.system("/bin/rm -rf %s/bindings" % this_dir)
 
 class PyangbindMiscTests(unittest.TestCase):
 
@@ -101,11 +92,19 @@ class PyangbindMiscTests(unittest.TestCase):
     self.assertEqual(type(self.instance.c.keys()[0]), int)
 
 if __name__ == '__main__':
+  keepfiles = False
+  args = sys.argv
+  if '-k' in args:
+    args.remove('-k')
+    keepfiles = True
+
   setup_test()
   T = unittest.main(exit=False)
   if len(T.result.errors) or len(T.result.failures):
     exitcode = 127
   else:
     exitcode = 0
-  teardown_test()
+
+  if keepfiles is False:
+    teardown_test()
   sys.exit(exitcode)

--- a/tests/presence/run.py
+++ b/tests/presence/run.py
@@ -11,8 +11,6 @@ import json
 
 TESTNAME = "presence"
 
-k = False
-
 # generate bindings in this folder
 def setup_test():
   try:
@@ -20,12 +18,7 @@ def setup_test():
   except getopt.GetoptError as e:
     sys.exit(127)
 
-  global k
   global this_dir
-
-  for o, a in opts:
-    if o in ["-k", "--keepfiles"]:
-      k = True
 
   pythonpath = os.environ.get("PATH_TO_PYBIND_TEST_PYTHON") if \
                 os.environ.get('PATH_TO_PYBIND_TEST_PYTHON') is not None \
@@ -49,12 +42,9 @@ def setup_test():
   os.system(cmd)
 
 def teardown_test():
-  global k
   global this_dir
-
-  if not k:
-    os.system("/bin/rm %s/bindings.py" % this_dir)
-    os.system("/bin/rm %s/bindings.pyc" % this_dir)
+  os.system("/bin/rm %s/bindings.py" % this_dir)
+  os.system("/bin/rm %s/bindings.pyc" % this_dir)
 
 class PyangbindPresenceTests(unittest.TestCase):
 
@@ -158,11 +148,19 @@ class PyangbindPresenceTests(unittest.TestCase):
 
 
 if __name__ == '__main__':
+  args = sys.argv
+  keepfiles = False
+  if '-k' in args:
+    args.remove('-k')
+    keepfiles = True
+
   setup_test()
   T = unittest.main(exit=False)
   if len(T.result.errors) or len(T.result.failures):
     exitcode = 127
   else:
     exitcode = 0
-  teardown_test()
+
+  if keepfiles is False:
+    teardown_test()
   sys.exit(exitcode)

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -49,5 +49,6 @@ if [ "$DELENV" == "true" ]; then
 fi
 
 if [ $FAIL -ne 0 ]; then
+  echo "OVERALL TEST RUN: Tests failed"
   exit 127
 fi

--- a/tests/submodules/run.py
+++ b/tests/submodules/run.py
@@ -9,8 +9,6 @@ from pyangbind.lib.yangtypes import safe_name
 import pyangbind.lib.pybindJSON as pbJ
 import json
 
-k = False
-
 # generate bindings in this folder
 def setup_test():
   try:
@@ -18,12 +16,7 @@ def setup_test():
   except getopt.GetoptError as e:
     sys.exit(127)
 
-  global k
   global this_dir
-
-  for o, a in opts:
-    if o in ["-k", "--keepfiles"]:
-      k = True
 
   pythonpath = os.environ.get("PATH_TO_PYBIND_TEST_PYTHON") if \
                 os.environ.get('PATH_TO_PYBIND_TEST_PYTHON') is not None \
@@ -46,12 +39,10 @@ def setup_test():
   os.system(cmd)
 
 def teardown_test():
-  global k
   global this_dir
 
-  if not k:
-    os.system("/bin/rm %s/bindings.py" % this_dir)
-    os.system("/bin/rm %s/bindings.pyc" % this_dir)
+  os.system("/bin/rm %s/bindings.py" % this_dir)
+  os.system("/bin/rm %s/bindings.pyc" % this_dir)
 
 class PyangbindSubmoduleTests(unittest.TestCase):
 
@@ -83,11 +74,17 @@ class PyangbindSubmoduleTests(unittest.TestCase):
     self.assertIs(passed, True)
 
 if __name__ == '__main__':
+  keepfiles = False
+  args = sys.argv
+  if '-k' in args:
+    args.remove('-k')
+    keepfiles = True
   setup_test()
   T = unittest.main(exit=False)
   if len(T.result.errors) or len(T.result.failures):
     exitcode = 127
   else:
     exitcode = 0
-  teardown_test()
+  if keepfiles is False:
+    teardown_test()
   sys.exit(exitcode)

--- a/tests/xpath/04-root/run.py
+++ b/tests/xpath/04-root/run.py
@@ -11,8 +11,6 @@ from pyangbind.lib.serialise import pybindJSONDecoder
 import pyangbind.lib.pybindJSON as pbJ
 import json
 
-k = False
-
 # generate bindings in this folder
 def setup_test():
   try:
@@ -20,7 +18,6 @@ def setup_test():
   except getopt.GetoptError as e:
     sys.exit(127)
 
-  global k
   global this_dir
 
   for o, a in opts:
@@ -49,12 +46,10 @@ def setup_test():
   os.system(cmd)
 
 def teardown_test():
-  global k
   global this_dir
 
-  if not k:
-    os.system("/bin/rm %s/bindings.py" % this_dir)
-    os.system("/bin/rm %s/bindings.pyc" % this_dir)
+  os.system("/bin/rm %s/bindings.py" % this_dir)
+  os.system("/bin/rm %s/bindings.pyc" % this_dir)
 
 class PyangbindXpathRootTC04(unittest.TestCase):
 
@@ -117,11 +112,17 @@ class PyangbindXpathRootTC04(unittest.TestCase):
     self.assertEqual(v, x)
 
 if __name__ == '__main__':
+  keepfiles = False
+  args = sys.argv
+  if '-k' in args:
+    args.remove('-k')
+    keepfiles = True
   setup_test()
   T = unittest.main(exit=False)
   if len(T.result.errors) or len(T.result.failures):
     exitcode = 127
   else:
     exitcode = 0
-  teardown_test()
+  if keepfiles is False:
+    teardown_test()
   sys.exit(exitcode)

--- a/tests/xpath/xpath_tests.sh
+++ b/tests/xpath/xpath_tests.sh
@@ -49,7 +49,7 @@ else
         fi
         if [ $? -ne 0 ]; then
             echo "TEST FAILED $i";
-            echo 127
+            exit 127
         fi
     done
 fi


### PR DESCRIPTION
``` 
* (M) tests/.../run.py
    - Fix tests that use unittest to keep files correctly as per
      #99, and building on top of solution in #100. ACK: @timmartin
 * (M) tests/.../*.sh
    - Fix erroneous return codes/ensure that overall test run status
      is noted.
```