### PR TITLE
Add support for typedefs to be scoped.

### DIFF
--- a/pyangbind/helpers/misc.py
+++ b/pyangbind/helpers/misc.py
@@ -34,9 +34,16 @@ def find_child_definitions(obj, defn, prefix, definitions):
     else:
       definitions["%s:%s" % (prefix, i.arg)] = i
 
-  for ch in obj.search('grouping'):
-    if ch.i_children:
-      find_child_definitions(ch, defn, prefix, definitions)
+  possible_parents = [
+                        'grouping', 'container',
+                        'list', 'rpc', 'input',
+                        'output', 'notification'
+                      ]
+
+  for parent_type in possible_parents:
+    for ch in obj.search(parent_type):
+      if ch.i_children:
+        find_child_definitions(ch, defn, prefix, definitions)
 
   return definitions
 

--- a/tests/typedef/run.py
+++ b/tests/typedef/run.py
@@ -168,6 +168,17 @@ def main():
       "union with an identityref within it was not set " + \
         "correctly: %s != %s (%s)" % (passed, i[1], i[0])
 
+  # check that typedefs nested in a container are supported
+  passed = None
+  try:
+    t.scoped_container_typedef.two = "amber"
+    passed = True
+  except ValueError:
+    passed = False
+
+  assert passed is True, \
+    "scoped typedef leaf within a container not set correctly"
+
   if not k:
     os.system("/bin/rm %s/bindings.py" % this_dir)
     os.system("/bin/rm %s/bindings.pyc" % this_dir)

--- a/tests/typedef/typedef.yang
+++ b/tests/typedef/typedef.yang
@@ -210,4 +210,16 @@ module typedef {
 
         uses scoped-typedef;
     }
+
+    container scoped-container-typedef {
+        typedef ATEST {
+            type string {
+                pattern "a.*";
+            }
+        }
+
+        leaf two {
+            type ATEST;
+        }
+    }
 }


### PR DESCRIPTION
```
 * (M) pyangbind/helpers/misc.py
   - Ensure that all locations where typedefs can be scoped are
     searched to define a type.
 * (M) tests/typedef/
   - Add unit tests to validate scoped typedefs as per bug in #98.
```