### PR TITLE
Resolved simple syntax errors in Python3

### DIFF
--- a/pyangbind/helpers/identity.py
+++ b/pyangbind/helpers/identity.py
@@ -66,7 +66,7 @@ class IdentityStore(object):
     return iter(self._store) 
 
   def build_store_from_definitions(self, ctx, defnd):
-    unresolved_identities = defnd.keys()
+    unresolved_identities = list(defnd.keys())
     unresolved_identity_count = {k: 0 for k in defnd}
     error_ids = []
 

--- a/pyangbind/lib/pybindJSON.py
+++ b/pyangbind/lib/pybindJSON.py
@@ -66,7 +66,7 @@ def load(fn, parent_pymod, yang_module, path_helper=None, extmethods=None,
              overwrite=False):
   try:
     f = json.load(open(fn, 'r'))
-  except IOError, m:
+  except IOError as m:
     raise pybindJSONIOError("could not open file to read: %s" % m)
   return loads(f, parent_pymod, yang_module, path_helper=path_helper,
                 extmethods=extmethods, overwrite=overwrite)
@@ -76,7 +76,7 @@ def load_ietf(fn, parent_pymod, yang_module, path_helper=None,
               extmethods=None, overwrite=False):
   try:
     f = json.load(open(fn, 'r'))
-  except IOError, m:
+  except IOError as m:
     raise pybindJSONIOError("Could not open file to read: %s" % m)
   return loads_ietf(f, parent_pymod, yang_module, path_helper,
             extmethods=extmethods, overwrite=overwrite)
@@ -162,7 +162,7 @@ def dump(obj, fn, indent=4, filter=True, skip_subtrees=[],
          mode="default"):
   try:
     fh = open(fn, 'w')
-  except IOError, m:
+  except IOError as m:
     raise pybindJSONIOError("could not open file for writing: %s" % m)
   fh.write(dumps(obj, indent=indent, filter=filter,
               skip_subtrees=skip_subtrees, mode=mode))

--- a/pyangbind/lib/yangtypes.py
+++ b/pyangbind/lib/yangtypes.py
@@ -661,7 +661,7 @@ def YANGListType(*args, **kwargs):
 
           self._members[k] = tmp
 
-        except ValueError, m:
+        except ValueError as m:
           raise KeyError("key value must be valid, %s" % m)
       else:
         self._members[k] = YANGDynClass(base=self._contained_class,
@@ -691,7 +691,7 @@ def YANGListType(*args, **kwargs):
         for kn in self._keyval.split(" "):
           try:
             keyargs[kn] = kwargs[kn]
-          except KeyError, m:
+          except KeyError as m:
             raise AttributeError("Keyword list add function must have all " +
                 "keys specified - cannot find %s" % m)
           k += "%s " % kwargs[kn]
@@ -774,7 +774,7 @@ def YANGListType(*args, **kwargs):
         del self._members[k]
         if self._path_helper:
           self._path_helper.unregister(obj_path)
-      except KeyError, m:
+      except KeyError as m:
         raise KeyError("key %s was not in list (%s)" % (k, m))
 
     def _item(self, *args, **kwargs):

--- a/pyangbind/plugin/pybind.py
+++ b/pyangbind/plugin/pybind.py
@@ -197,7 +197,7 @@ INT_RANGE_TYPES = ["uint8", "uint16", "uint32", "uint64",
                     "int8", "int16", "int32", "int64"]
 
 # The types that are built-in to YANG
-YANG_BUILTIN_TYPES = class_map.keys() + \
+YANG_BUILTIN_TYPES = list(class_map.keys()) + \
                       ["container", "list", "rpc", "notification", "leafref"]
 
 
@@ -300,7 +300,7 @@ def build_pybind(ctx, modules, fd):
   # we provided but then unused.
   if len(ctx.errors):
     for e in ctx.errors:
-      print "INFO: encountered %s" % str(e)
+      print("INFO: encountered %s" % e)
       if not e[1] in ["UNUSED_IMPORT", "PATTERN_ERROR"]:
         sys.stderr.write("FATAL: pyangbind cannot build module that pyang" +
           " has found errors with.\n")
@@ -475,7 +475,7 @@ def build_typedefs(ctx, defnd):
     unresolved_tc[i] = 0
   unresolved_t = defnd.keys()
   error_ids = []
-  known_types = class_map.keys()
+  known_types = list(class_map.keys())
   known_types.append('enumeration')
   known_types.append('leafref')
   base_types = copy.deepcopy(known_types)
@@ -674,13 +674,13 @@ def get_children(ctx, fd, i_children, module, parent, path=str(),
     if not os.path.exists(fpath):
       try:
         nfd = open(fpath, 'w')
-      except IOError, m:
+      except IOError as m:
         raise IOError("could not open pyangbind output file (%s)" % m)
       nfd.write(ctx.pybind_common_hdr)
     else:
       try:
         nfd = open(fpath, 'a')
-      except IOError, w:
+      except IOError as w:
         raise IOError("could not open pyangbind output file (%s)" % m)
   else:
     # If we weren't asked to split the files, then just use the file handle

--- a/tests/binary/run.py
+++ b/tests/binary/run.py
@@ -12,7 +12,7 @@ def main():
   try:
     opts, args = getopt.getopt(sys.argv[1:], "k", ["keepfiles"])
   except getopt.GetoptError as e:
-    print str(e)
+    print(str(e))
     sys.exit(127)
 
   k = False

--- a/tests/boolean-empty/run.py
+++ b/tests/boolean-empty/run.py
@@ -13,7 +13,7 @@ def main():
   try:
     opts, args = getopt.getopt(sys.argv[1:], "k", ["keepfiles"])
   except getopt.GetoptError as e:
-    print str(e)
+    print(str(e))
     sys.exit(127)
 
   k = False

--- a/tests/choice/run.py
+++ b/tests/choice/run.py
@@ -12,7 +12,7 @@ def main():
   try:
     opts, args = getopt.getopt(sys.argv[1:], "k", ["keepfiles"])
   except getopt.GetoptError as e:
-    print str(e)
+    print(str(e))
     sys.exit(127)
 
   keepfiles = False

--- a/tests/config-false/run.py
+++ b/tests/config-false/run.py
@@ -12,7 +12,7 @@ def main():
   try:
     opts, args = getopt.getopt(sys.argv[1:], "k", ["keepfiles"])
   except getopt.GetoptError as e:
-    print str(e)
+    print(str(e))
     sys.exit(127)
 
   keepfiles = False

--- a/tests/decimal64/run.py
+++ b/tests/decimal64/run.py
@@ -12,7 +12,7 @@ def main():
   try:
     opts, args = getopt.getopt(sys.argv[1:], "k", ["keepfiles"])
   except getopt.GetoptError as e:
-    print str(e)
+    print(str(e))
     sys.exit(127)
 
   k = False
@@ -69,7 +69,7 @@ def main():
     try:
       q.container.dec64LeafWithRange = i[0]
       passed = True
-    except ValueError, m:
+    except ValueError:
       pass
     assert passed == i[1], \
         "decimal64 leaf with range was not correctly set (%f -> %s != %s)" \

--- a/tests/enumeration/run.py
+++ b/tests/enumeration/run.py
@@ -12,7 +12,7 @@ def main():
   try:
     opts, args = getopt.getopt(sys.argv[1:], "k", ["keepfiles"])
   except getopt.GetoptError as e:
-    print str(e)
+    print(str(e))
     sys.exit(127)
 
   k = False

--- a/tests/extensions/run.py
+++ b/tests/extensions/run.py
@@ -12,7 +12,7 @@ def main():
   try:
     opts, args = getopt.getopt(sys.argv[1:], "k", ["keepfiles"])
   except getopt.GetoptError as e:
-    print str(e)
+    print(str(e))
     sys.exit(127)
 
   keep = False

--- a/tests/identityref/run.py
+++ b/tests/identityref/run.py
@@ -12,7 +12,7 @@ def main():
   try:
     opts, args = getopt.getopt(sys.argv[1:], "k", ["keepfiles"])
   except getopt.GetoptError as e:
-    print str(e)
+    print(str(e))
     sys.exit(127)
 
   keepfiles = False

--- a/tests/int/run.py
+++ b/tests/int/run.py
@@ -12,7 +12,7 @@ def main():
   try:
     opts, args = getopt.getopt(sys.argv[1:], "k", ["keepfiles"])
   except getopt.GetoptError as e:
-    print str(e)
+    print(str(e))
     sys.exit(127)
 
   k = False
@@ -207,7 +207,7 @@ def main():
     try:
       u.int_container.complex_range_two = i[0]
       passed = True
-    except ValueError, m:
+    except ValueError:
       pass
     assert passed == i[1], \
         "complex range with spaces and three elements not set correctly " + \
@@ -218,7 +218,7 @@ def main():
     try:
       u.int_container.complex_range_with_negative = i[0]
       passed = True
-    except ValueError, m:
+    except ValueError:
       pass
     assert passed == i[1], \
          "complex range with negatives not set correctly (%d -> %s != %s)" % \
@@ -230,7 +230,7 @@ def main():
     try:
       u.int_container.intLeafWithRange = i[0]
       passed = True
-    except ValueError, m:
+    except ValueError:
       pass
     assert passed == i[1], \
         "complex range with negatives and additional spaces not set " + \
@@ -242,7 +242,7 @@ def main():
     try:
       u.int_container.complex_range_with_equals_case = i[0]
       passed = True
-    except ValueError, m:
+    except ValueError:
       pass
     assert passed == i[1], \
         "complex range with equals case was not set correctly " + \
@@ -261,7 +261,7 @@ def main():
       passed = True
       try:
         set_attr(vals[0])
-      except ValueError, m:
+      except ValueError:
         passed = False
       assert passed is True, "Could not set int size %s to %d"  % \
         (elem, val)
@@ -269,7 +269,7 @@ def main():
     passed = False
     try:
       set_attr(vals[0] - 1)
-    except ValueError, m:
+    except ValueError:
       passed = True
 
     assert passed is True, "Incorrectly set int size %s to %d" % \
@@ -278,7 +278,7 @@ def main():
     passed = False
     try:
       set_attr(vals[1] + 1)
-    except ValueError, m:
+    except ValueError:
       passed = True
 
     assert passed is True, "Incorrectly set int size %s to %d" % \

--- a/tests/leaf-list/run.py
+++ b/tests/leaf-list/run.py
@@ -12,7 +12,7 @@ def main():
   try:
     opts, args = getopt.getopt(sys.argv[1:], "k", ["keepfiles"])
   except getopt.GetoptError as e:
-    print str(e)
+    print(str(e))
     sys.exit(127)
 
   k = False
@@ -62,7 +62,7 @@ def main():
 
   try:
     leaflist_instance.container.leaflist.append(int(1))
-  except ValueError, m:
+  except ValueError:
     pass
 
   assert len(leaflist_instance.container.leaflist) == 1, \

--- a/tests/list/run.py
+++ b/tests/list/run.py
@@ -12,7 +12,7 @@ def main():
   try:
     opts, args = getopt.getopt(sys.argv[1:], "k", ["keepfiles"])
   except getopt.GetoptError as e:
-    print str(e)
+    print(str(e))
     sys.exit(127)
 
   keepfiles = False
@@ -54,7 +54,7 @@ def main():
 
   try:
     test_instance.list_container.list_element.add("wrong-key-type")
-  except KeyError, m:
+  except KeyError:
     pass
   assert len(test_instance.list_container.list_element) == 0, \
     "list item erroneously added with wrong key type"
@@ -107,7 +107,7 @@ def main():
 
   try:
     test_instance.list_container.list_element[2] = "anInvalidType"
-  except ValueError, m:
+  except ValueError:
     pass
   assert len(test_instance.list_container.list_element) == 0, \
     "item that was invalid was added to the list"

--- a/tests/nested-containers/run.py
+++ b/tests/nested-containers/run.py
@@ -12,7 +12,7 @@ def main():
   try:
     opts, args = getopt.getopt(sys.argv[1:], "k", ["keepfiles"])
   except getopt.GetoptError as e:
-    print str(e)
+    print(str(e))
     sys.exit(127)
 
   k = False

--- a/tests/notification/run.py
+++ b/tests/notification/run.py
@@ -12,7 +12,7 @@ def main():
   try:
     opts, args = getopt.getopt(sys.argv[1:], "k", ["keepfiles"])
   except getopt.GetoptError as e:
-    print str(e)
+    print(str(e))
     sys.exit(127)
 
   k = False
@@ -50,9 +50,9 @@ def main():
     from bindings.notification_notification import alert_one
     ch = alert_one.alert_one(path_helper=ph)
     ch.argument = "test"
-  except ImportError, m:
+  except ImportError as m:
     import_error = m
-  except ValueError, m:
+  except ValueError as m:
     set_argument_error = m
 
   assert import_error is None, "Could not import alert_one notification: %s" \
@@ -65,9 +65,9 @@ def main():
   try:
     from bindings.notification_notification import alert_two
     ch = alert_two.alert_two(path_helper=ph)
-  except ImportError, m:
+  except ImportError as m:
     import_error = m
-  except TypeError, m:
+  except TypeError as m:
     instantiation_error = m
 
   assert import_error is None, "Could not import alert_two notification: %s" \
@@ -79,7 +79,7 @@ def main():
   try:
     ch.arg_one = 10
     ch.arg_two = 20
-  except ValueError, m:
+  except ValueError as m:
     val_set = False
 
   assert val_set is True, "Could not set leaf arguments directly" + \
@@ -95,9 +95,9 @@ def main():
   value_err = None
   try:
     ch3.arguments.arg_one = "test string"
-  except AttributeError, m:
+  except AttributeError as m:
     attribute_err = m
-  except ValueError, m:
+  except ValueError as m:
     value_err = m
 
   assert attribute_err is None, "Expected attribute for ch3 did not exist" \
@@ -109,9 +109,9 @@ def main():
   value_err = None
   try:
     ch3.arguments.arg_two = "test string"
-  except AttributeError, m:
+  except AttributeError as m:
     attribute_err = m
-  except ValueError, m:
+  except ValueError as m:
     value_err = m
 
   assert attribute_err is None, "Expected attribute for ch3 did not exist" \
@@ -123,9 +123,9 @@ def main():
   value_err = None
   try:
     ch4.arguments_one.arg_one = "test string"
-  except AttributeError, m:
+  except AttributeError as m:
     attribute_err = m
-  except ValueError, m:
+  except ValueError as m:
     value_err = m
 
   assert attribute_err is None, "Expected attribute for ch4 did not exist" \
@@ -137,9 +137,9 @@ def main():
   value_err = None
   try:
     ch4.arguments_two.arg_two = "test string"
-  except AttributeError, m:
+  except AttributeError as m:
     attribute_err = m
-  except ValueError, m:
+  except ValueError as m:
     value_err = m
 
   assert attribute_err is None, "Expected attribute for ch4 did not exist" \
@@ -155,7 +155,7 @@ def main():
   set_v = True
   try:
     ch5.argument = 'five'
-  except ValueError, m:
+  except ValueError:
     set_v = False
 
   assert set_v is True, "Could not set value of a leafref in a notification to a" + \
@@ -164,7 +164,7 @@ def main():
   set_v = True
   try:
     ch5.argument = 'fish'
-  except ValueError, m:
+  except ValueError:
     set_v = False
 
   assert set_v is False, "Set value of a leafref in a notification to a" + \

--- a/tests/openconfig-bgp-juniper/run.py
+++ b/tests/openconfig-bgp-juniper/run.py
@@ -12,7 +12,7 @@ def main():
   try:
     opts, args = getopt.getopt(sys.argv[1:], "k", ["keepfiles"])
   except getopt.GetoptError as e:
-    print str(e)
+    print(str(e))
     sys.exit(127)
 
   k = False

--- a/tests/rpc/run.py
+++ b/tests/rpc/run.py
@@ -12,7 +12,7 @@ def main():
   try:
     opts, args = getopt.getopt(sys.argv[1:], "k", ["keepfiles"])
   except getopt.GetoptError as e:
-    print str(e)
+    print(str(e))
     sys.exit(127)
 
   k = False
@@ -50,9 +50,9 @@ def main():
     from bindings.rpc_rpc import check
     ch = check.check(path_helper=ph)
     ch.input.argument = "test"
-  except ImportError, m:
+  except ImportError as m:
     import_error = m
-  except ValueError, m:
+  except ValueError as m:
     set_argument_error = m
 
   assert import_error is None, "Could not import check RPC: %s" \
@@ -65,9 +65,9 @@ def main():
   try:
     from bindings.rpc_rpc.check_two import output as chktwo_output
     ch = chktwo_output.output(path_helper=ph)
-  except ImportError, m:
+  except ImportError as m:
     import_error = m
-  except TypeError, m:
+  except TypeError as m:
     instantiation_error = m
 
   assert import_error is None, "Could not import check_two RPC output: %s" \
@@ -79,7 +79,7 @@ def main():
   try:
     ch.arg_one = 10
     ch.arg_two = 20
-  except ValueError, m:
+  except ValueError as m:
     val_set = False
 
   assert val_set is True, "Could not set output leaf arguments directly" + \
@@ -96,9 +96,9 @@ def main():
   value_err = None
   try:
     ch3.input.arguments.arg_one = "test string"
-  except AttributeError, m:
+  except AttributeError as m:
     attribute_err = m
-  except ValueError, m:
+  except ValueError as m:
     value_err = m
 
   assert attribute_err is None, "Expected attribute for ch3 did not exist" \
@@ -110,9 +110,9 @@ def main():
   value_err = None
   try:
     ch3.input.arguments.arg_two = "test string"
-  except AttributeError, m:
+  except AttributeError as m:
     attribute_err = m
-  except ValueError, m:
+  except ValueError as m:
     value_err = m
 
   assert attribute_err is None, "Expected attribute for ch3 did not exist" \
@@ -124,9 +124,9 @@ def main():
   value_err = None
   try:
     ch4.output.arguments.arg_one = "test string"
-  except AttributeError, m:
+  except AttributeError as m:
     attribute_err = m
-  except ValueError, m:
+  except ValueError as m:
     value_err = m
 
   assert attribute_err is None, "Expected attribute for ch4 did not exist" \
@@ -138,9 +138,9 @@ def main():
   value_err = None
   try:
     ch4.output.arguments_two.arg_two = "test string"
-  except AttributeError, m:
+  except AttributeError as m:
     attribute_err = m
-  except ValueError, m:
+  except ValueError as m:
     value_err = m
 
   assert attribute_err is None, "Expected attribute for ch4 did not exist" \
@@ -152,9 +152,9 @@ def main():
   value_err = None
   try:
     ch5.input.arguments.arg_one = "test string"
-  except AttributeError, m:
+  except AttributeError as m:
     attribute_err = m
-  except ValueError, m:
+  except ValueError as m:
     value_err = m
 
   assert attribute_err is None, "Expected attribute for ch5 did not exist" \
@@ -166,9 +166,9 @@ def main():
   value_err = None
   try:
     ch5.output.return_values.return_val = 10
-  except AttributeError, m:
+  except AttributeError as m:
     attribute_err = m
-  except ValueError, m:
+  except ValueError as m:
     value_err = m
 
   assert attribute_err is None, "Expected attribute for ch4 did not exist" \
@@ -188,7 +188,7 @@ def main():
   set_v = True
   try:
     ch6.input.argument = 'six'
-  except ValueError, m:
+  except ValueError as m:
     set_v = False
 
   assert set_v is True, "Could not set value of a leafref in an RPC to a" + \
@@ -197,7 +197,7 @@ def main():
   set_v = True
   try:
     ch6.input.argument = 'fish'
-  except ValueError, m:
+  except ValueError as m:
     set_v = False
 
   assert set_v is False, "Set value of a leafref in an RPC to a" + \

--- a/tests/split-classes/run.py
+++ b/tests/split-classes/run.py
@@ -12,7 +12,7 @@ def main():
   try:
     opts, args = getopt.getopt(sys.argv[1:], "k", ["keepfiles"])
   except getopt.GetoptError as e:
-    print str(e)
+    print(str(e))
     sys.exit(127)
 
   keepfiles = False

--- a/tests/string/run.py
+++ b/tests/string/run.py
@@ -12,7 +12,7 @@ def main():
   try:
     opts, args = getopt.getopt(sys.argv[1:], "k", ["keepfiles"])
   except getopt.GetoptError as e:
-    print str(e)
+    print(str(e))
     sys.exit(127)
 
   k = False

--- a/tests/typedef/run.py
+++ b/tests/typedef/run.py
@@ -12,7 +12,7 @@ def main():
   try:
     opts, args = getopt.getopt(sys.argv[1:], "k", ["keepfiles"])
   except getopt.GetoptError as e:
-    print str(e)
+    print(str(e))
     sys.exit(127)
 
   k = False

--- a/tests/uint/run.py
+++ b/tests/uint/run.py
@@ -12,7 +12,7 @@ def main():
   try:
     opts, args = getopt.getopt(sys.argv[1:], "k", ["keepfiles"])
   except getopt.GetoptError as e:
-    print str(e)
+    print(str(e))
     sys.exit(127)
 
   k = False
@@ -165,7 +165,7 @@ def main():
       passed = True
       try:
         set_attr(vals[0])
-      except ValueError, m:
+      except ValueError as m:
         passed = False
       assert passed is True, "Could not set int size %s to %d"  % \
         (elem, val)
@@ -173,7 +173,7 @@ def main():
     passed = False
     try:
       set_attr(vals[0] - 1)
-    except ValueError, m:
+    except ValueError as m:
       passed = True
 
     assert passed is True, "Incorrectly set int size %s to %d" % \
@@ -182,7 +182,7 @@ def main():
     passed = False
     try:
       set_attr(vals[1] + 1)
-    except ValueError, m:
+    except ValueError as m:
       passed = True
 
     assert passed is True, "Incorrectly set int size %s to %d" % \

--- a/tests/union/run.py
+++ b/tests/union/run.py
@@ -12,7 +12,7 @@ def main():
   try:
     opts, args = getopt.getopt(sys.argv[1:], "k", ["keepfiles"])
   except getopt.GetoptError as e:
-    print str(e)
+    print(str(e))
     sys.exit(127)
 
   k = False
@@ -117,7 +117,7 @@ def main():
       "leaf-list of union of unions did not correctly validate value " + \
         "(%s -> %s != %s)" % (i[0], passed, i[1])
 
-    print u.container.u9
+    print(u.container.u9)
 
   # 10-20, 30-40 or starting with a and b
   for i in [(15, True), (35, True), ("aardvark", True), ("bear", True),


### PR DESCRIPTION
This change has fixes for the basic syntax errors that occur with Python 3. I'm doing some work to make the code Python 3 compatible and this is the first step. It's not enough on its own, but merging these simple changes will mean there's less noise when applying later more involved patches.