### PR TITLE
support for Decimal object added. This fixes serializing Decimal objects as unicode objects in json

### DIFF
--- a/pyangbind/lib/serialise.py
+++ b/pyangbind/lib/serialise.py
@@ -93,6 +93,9 @@ class pybindJSONEncoder(json.JSONEncoder):
       elif pybc == "TypedListType":
         return [self.default(i) for i in obj]
 
+    # Check for Decimal
+    if isinstance(obj, Decimal):
+       return unicode(obj) if mode == "ietf" else float(obj)
     # Map based on YANG type
     if orig_yangt in ["leafref"]:
       return self.default(obj._get()) if hasattr(obj, "_get") \


### PR DESCRIPTION
This PR fixes the issue, openconfig-bgp.yang serializing to json fails #109