### PR TITLE
Resolve decimal serialisation issue, update for OC-BGP changes.

### DIFF
--- a/pyangbind/lib/serialise.py
+++ b/pyangbind/lib/serialise.py
@@ -154,6 +154,8 @@ class pybindJSONEncoder(json.JSONEncoder):
       return int(obj)
     elif type(obj) in [YANGBool, bool]:
       return bool(obj)
+    elif type(obj) in [Decimal]:
+      return unicode(obj) if mode == "ietf" else float(obj)
 
     raise AttributeError("Unmapped type: %s, %s, %s, %s, %s, %s" %
                                   (elem_name, orig_yangt, pybc, pyc,

--- a/tests/integration/openconfig-bgp/testdata/tc010.json
+++ b/tests/integration/openconfig-bgp/testdata/tc010.json
@@ -1,0 +1,22 @@
+{
+    "bgp": {
+        "neighbors": {
+            "neighbor": {
+                "192.1.1.1": {
+                    "neighbor-address": "192.1.1.1", 
+                    "config": {
+                        "neighbor-address": "192.1.1.1", 
+                        "peer-as": 5400, 
+                        "description": "a fictional transit session"
+                    }
+                }
+            }
+        }, 
+        "global": {
+            "config": {
+                "as": 2856, 
+                "router-id": "192.0.2.1"
+            }
+        }
+    }
+}

--- a/tests/integration/openconfig-bgp/testdata/tc020.json
+++ b/tests/integration/openconfig-bgp/testdata/tc020.json
@@ -1,0 +1,299 @@
+{
+    "bgp": {
+        "neighbors": {
+            "neighbor": {
+                "192.1.1.1": {
+                    "neighbor-address": "192.1.1.1", 
+                    "route-reflector": {
+                        "state": {
+                            "route-reflector-client": false, 
+                            "route-reflector-cluster-id": 0
+                        }, 
+                        "config": {
+                            "route-reflector-client": false, 
+                            "route-reflector-cluster-id": 0
+                        }
+                    }, 
+                    "apply-policy": {
+                        "state": {
+                            "export-policy": [], 
+                            "import-policy": [], 
+                            "default-export-policy": "REJECT_ROUTE", 
+                            "default-import-policy": "REJECT_ROUTE"
+                        }, 
+                        "config": {
+                            "export-policy": [], 
+                            "import-policy": [], 
+                            "default-export-policy": "REJECT_ROUTE", 
+                            "default-import-policy": "REJECT_ROUTE"
+                        }
+                    }, 
+                    "error-handling": {
+                        "state": {
+                            "treat-as-withdraw": false, 
+                            "erroneous-update-messages": 0
+                        }, 
+                        "config": {
+                            "treat-as-withdraw": false
+                        }
+                    }, 
+                    "afi-safis": {
+                        "afi-safi": {}
+                    }, 
+                    "state": {
+                        "send-community": "NONE", 
+                        "session-state": "", 
+                        "local-as": 0, 
+                        "description": "", 
+                        "route-flap-damping": false, 
+                        "supported-capabilities": [], 
+                        "enabled": true, 
+                        "peer-as": 0, 
+                        "neighbor-address": "", 
+                        "peer-group": false, 
+                        "remove-private-as": "", 
+                        "auth-password": "", 
+                        "dynamically-configured": false, 
+                        "messages": {
+                            "received": {
+                                "NOTIFICATION": 0, 
+                                "UPDATE": 0
+                            }, 
+                            "sent": {
+                                "NOTIFICATION": 0, 
+                                "UPDATE": 0
+                            }
+                        }, 
+                        "established-transitions": 0, 
+                        "peer-type": "", 
+                        "queues": {
+                            "input": 0, 
+                            "output": 0
+                        }, 
+                        "last-established": 0
+                    }, 
+                    "add-paths": {
+                        "state": {
+                            "receive": false, 
+                            "eligible-prefix-policy": false, 
+                            "send-max": 0
+                        }, 
+                        "config": {
+                            "receive": false, 
+                            "eligible-prefix-policy": false, 
+                            "send-max": 0
+                        }
+                    }, 
+                    "timers": {
+                        "state": {
+                            "minimum-advertisement-interval": 30.0, 
+                            "connect-retry": 30.0, 
+                            "hold-time": 90.0, 
+                            "negotiated-hold-time": 0.0, 
+                            "keepalive-interval": 30.0
+                        }, 
+                        "config": {
+                            "connect-retry": 30.0, 
+                            "hold-time": 90.0, 
+                            "minimum-advertisement-interval": 30.0, 
+                            "keepalive-interval": 30.0
+                        }
+                    }, 
+                    "as-path-options": {
+                        "state": {
+                            "allow-own-as": 0, 
+                            "replace-peer-as": false
+                        }, 
+                        "config": {
+                            "allow-own-as": 0, 
+                            "replace-peer-as": false
+                        }
+                    }, 
+                    "ebgp-multihop": {
+                        "state": {
+                            "enabled": false, 
+                            "multihop-ttl": 0
+                        }, 
+                        "config": {
+                            "enabled": false, 
+                            "multihop-ttl": 0
+                        }
+                    }, 
+                    "logging-options": {
+                        "state": {
+                            "log-neighbor-state-changes": true
+                        }, 
+                        "config": {
+                            "log-neighbor-state-changes": true
+                        }
+                    }, 
+                    "use-multiple-paths": {
+                        "ebgp": {
+                            "state": {
+                                "allow-multiple-as": false
+                            }, 
+                            "config": {
+                                "allow-multiple-as": false
+                            }
+                        }, 
+                        "state": {
+                            "enabled": false
+                        }, 
+                        "config": {
+                            "enabled": false
+                        }
+                    }, 
+                    "config": {
+                        "send-community": "NONE", 
+                        "neighbor-address": "192.1.1.1", 
+                        "local-as": 0, 
+                        "description": "a fictional transit session", 
+                        "route-flap-damping": false, 
+                        "enabled": true, 
+                        "peer-as": 5400, 
+                        "peer-group": false, 
+                        "remove-private-as": "", 
+                        "auth-password": "", 
+                        "peer-type": ""
+                    }, 
+                    "transport": {
+                        "state": {
+                            "local-address": "", 
+                            "local-port": 0, 
+                            "tcp-mss": 0, 
+                            "remote-port": 0, 
+                            "passive-mode": false, 
+                            "remote-address": "", 
+                            "mtu-discovery": false
+                        }, 
+                        "config": {
+                            "tcp-mss": 0, 
+                            "local-address": "", 
+                            "mtu-discovery": false, 
+                            "passive-mode": false
+                        }
+                    }, 
+                    "graceful-restart": {
+                        "state": {
+                            "peer-restart-time": 0, 
+                            "enabled": false, 
+                            "stale-routes-time": 0.0, 
+                            "mode": "", 
+                            "helper-only": false, 
+                            "local-restarting": false, 
+                            "restart-time": 0, 
+                            "peer-restarting": false
+                        }, 
+                        "config": {
+                            "helper-only": false, 
+                            "enabled": false, 
+                            "stale-routes-time": 0.0, 
+                            "restart-time": 0
+                        }
+                    }
+                }
+            }
+        }, 
+        "peer-groups": {
+            "peer-group": {}
+        }, 
+        "global": {
+            "route-selection-options": {
+                "state": {
+                    "enable-aigp": false, 
+                    "ignore-as-path-length": false, 
+                    "advertise-inactive-routes": false, 
+                    "ignore-next-hop-igp-metric": false, 
+                    "always-compare-med": false, 
+                    "external-compare-router-id": true
+                }, 
+                "config": {
+                    "enable-aigp": false, 
+                    "ignore-as-path-length": false, 
+                    "advertise-inactive-routes": false, 
+                    "ignore-next-hop-igp-metric": false, 
+                    "always-compare-med": false, 
+                    "external-compare-router-id": true
+                }
+            }, 
+            "state": {
+                "total-prefixes": 0, 
+                "as": 0, 
+                "router-id": "", 
+                "total-paths": 0
+            }, 
+            "afi-safis": {
+                "afi-safi": {}
+            }, 
+            "graceful-restart": {
+                "state": {
+                    "helper-only": false, 
+                    "enabled": false, 
+                    "stale-routes-time": 0.0, 
+                    "restart-time": 0
+                }, 
+                "config": {
+                    "helper-only": false, 
+                    "enabled": false, 
+                    "stale-routes-time": 0.0, 
+                    "restart-time": 0
+                }
+            }, 
+            "dynamic-neighbor-prefixes": {
+                "dynamic-neighbor-prefix": {}
+            }, 
+            "use-multiple-paths": {
+                "ibgp": {
+                    "state": {
+                        "maximum-paths": 1
+                    }, 
+                    "config": {
+                        "maximum-paths": 1
+                    }
+                }, 
+                "ebgp": {
+                    "state": {
+                        "allow-multiple-as": false, 
+                        "maximum-paths": 1
+                    }, 
+                    "config": {
+                        "allow-multiple-as": false, 
+                        "maximum-paths": 1
+                    }
+                }, 
+                "state": {
+                    "enabled": false
+                }, 
+                "config": {
+                    "enabled": false
+                }
+            }, 
+            "config": {
+                "as": 2856, 
+                "router-id": "192.0.2.1"
+            }, 
+            "confederation": {
+                "state": {
+                    "identifier": 0, 
+                    "enabled": false, 
+                    "member-as": []
+                }, 
+                "config": {
+                    "identifier": 0, 
+                    "enabled": false, 
+                    "member-as": []
+                }
+            }, 
+            "default-route-distance": {
+                "state": {
+                    "external-route-distance": 0, 
+                    "internal-route-distance": 0
+                }, 
+                "config": {
+                    "external-route-distance": 0, 
+                    "internal-route-distance": 0
+                }
+            }
+        }
+    }
+}

--- a/tests/integration/openconfig-bgp/testdata/tc030.json
+++ b/tests/integration/openconfig-bgp/testdata/tc030.json
@@ -1,0 +1,22 @@
+{
+    "openconfig-bgp:bgp": {
+        "neighbors": {
+            "neighbor": [
+                {
+                    "neighbor-address": "192.1.1.1", 
+                    "config": {
+                        "neighbor-address": "192.1.1.1", 
+                        "peer-as": 5400, 
+                        "description": "a fictional transit session"
+                    }
+                }
+            ]
+        }, 
+        "global": {
+            "config": {
+                "as": 2856, 
+                "router-id": "192.0.2.1"
+            }
+        }
+    }
+}

--- a/tests/integration/openconfig-bgp/testdata/tc040.json
+++ b/tests/integration/openconfig-bgp/testdata/tc040.json
@@ -1,0 +1,287 @@
+{
+    "openconfig-bgp:bgp": {
+        "neighbors": {
+            "neighbor": [
+                {
+                    "neighbor-address": "192.1.1.1", 
+                    "route-reflector": {
+                        "state": {
+                            "route-reflector-client": false, 
+                            "route-reflector-cluster-id": 0
+                        }, 
+                        "config": {
+                            "route-reflector-client": false, 
+                            "route-reflector-cluster-id": 0
+                        }
+                    }, 
+                    "apply-policy": {
+                        "state": {
+                            "export-policy": [], 
+                            "import-policy": [], 
+                            "default-export-policy": "", 
+                            "default-import-policy": ""
+                        }, 
+                        "config": {
+                            "export-policy": [], 
+                            "import-policy": [], 
+                            "default-export-policy": "", 
+                            "default-import-policy": ""
+                        }
+                    }, 
+                    "error-handling": {
+                        "state": {
+                            "treat-as-withdraw": false, 
+                            "erroneous-update-messages": 0
+                        }, 
+                        "config": {
+                            "treat-as-withdraw": false
+                        }
+                    }, 
+                    "as-path-options": {
+                        "state": {
+                            "allow-own-as": 0, 
+                            "replace-peer-as": false
+                        }, 
+                        "config": {
+                            "allow-own-as": 0, 
+                            "replace-peer-as": false
+                        }
+                    }, 
+                    "state": {
+                        "send-community": "", 
+                        "session-state": "", 
+                        "local-as": 0, 
+                        "description": "", 
+                        "route-flap-damping": false, 
+                        "supported-capabilities": [], 
+                        "enabled": false, 
+                        "peer-as": 0, 
+                        "neighbor-address": "", 
+                        "peer-group": false, 
+                        "remove-private-as": "", 
+                        "auth-password": "", 
+                        "dynamically-configured": false, 
+                        "messages": {
+                            "received": {
+                                "NOTIFICATION": "0", 
+                                "UPDATE": "0"
+                            }, 
+                            "sent": {
+                                "NOTIFICATION": "0", 
+                                "UPDATE": "0"
+                            }
+                        }, 
+                        "established-transitions": "0", 
+                        "peer-type": "", 
+                        "queues": {
+                            "input": 0, 
+                            "output": 0
+                        }, 
+                        "last-established": "0"
+                    }, 
+                    "add-paths": {
+                        "state": {
+                            "receive": false, 
+                            "eligible-prefix-policy": false, 
+                            "send-max": 0
+                        }, 
+                        "config": {
+                            "receive": false, 
+                            "eligible-prefix-policy": false, 
+                            "send-max": 0
+                        }
+                    }, 
+                    "timers": {
+                        "state": {
+                            "minimum-advertisement-interval": "0", 
+                            "connect-retry": "0", 
+                            "hold-time": "0", 
+                            "negotiated-hold-time": "0", 
+                            "keepalive-interval": "0"
+                        }, 
+                        "config": {
+                            "connect-retry": "0", 
+                            "hold-time": "0", 
+                            "minimum-advertisement-interval": "0", 
+                            "keepalive-interval": "0"
+                        }
+                    }, 
+                    "ebgp-multihop": {
+                        "state": {
+                            "enabled": false, 
+                            "multihop-ttl": 0
+                        }, 
+                        "config": {
+                            "enabled": false, 
+                            "multihop-ttl": 0
+                        }
+                    }, 
+                    "logging-options": {
+                        "state": {
+                            "log-neighbor-state-changes": false
+                        }, 
+                        "config": {
+                            "log-neighbor-state-changes": false
+                        }
+                    }, 
+                    "use-multiple-paths": {
+                        "ebgp": {
+                            "state": {
+                                "allow-multiple-as": false
+                            }, 
+                            "config": {
+                                "allow-multiple-as": false
+                            }
+                        }, 
+                        "state": {
+                            "enabled": false
+                        }, 
+                        "config": {
+                            "enabled": false
+                        }
+                    }, 
+                    "config": {
+                        "send-community": "", 
+                        "neighbor-address": "192.1.1.1", 
+                        "local-as": 0, 
+                        "description": "a fictional transit session", 
+                        "route-flap-damping": false, 
+                        "enabled": false, 
+                        "peer-as": 5400, 
+                        "peer-group": false, 
+                        "remove-private-as": "", 
+                        "auth-password": "", 
+                        "peer-type": ""
+                    }, 
+                    "transport": {
+                        "state": {
+                            "local-address": "", 
+                            "local-port": 0, 
+                            "tcp-mss": 0, 
+                            "remote-port": 0, 
+                            "passive-mode": false, 
+                            "remote-address": "", 
+                            "mtu-discovery": false
+                        }, 
+                        "config": {
+                            "tcp-mss": 0, 
+                            "local-address": "", 
+                            "mtu-discovery": false, 
+                            "passive-mode": false
+                        }
+                    }, 
+                    "graceful-restart": {
+                        "state": {
+                            "peer-restart-time": 0, 
+                            "enabled": false, 
+                            "stale-routes-time": "0", 
+                            "mode": "", 
+                            "helper-only": false, 
+                            "local-restarting": false, 
+                            "restart-time": 0, 
+                            "peer-restarting": false
+                        }, 
+                        "config": {
+                            "helper-only": false, 
+                            "enabled": false, 
+                            "stale-routes-time": "0", 
+                            "restart-time": 0
+                        }
+                    }
+                }
+            ]
+        }, 
+        "global": {
+            "config": {
+                "as": 2856, 
+                "router-id": "192.0.2.1"
+            }, 
+            "graceful-restart": {
+                "state": {
+                    "helper-only": false, 
+                    "enabled": false, 
+                    "stale-routes-time": "0", 
+                    "restart-time": 0
+                }, 
+                "config": {
+                    "helper-only": false, 
+                    "enabled": false, 
+                    "stale-routes-time": "0", 
+                    "restart-time": 0
+                }
+            }, 
+            "state": {
+                "total-prefixes": 0, 
+                "as": 0, 
+                "router-id": "", 
+                "total-paths": 0
+            }, 
+            "use-multiple-paths": {
+                "ibgp": {
+                    "state": {
+                        "maximum-paths": 0
+                    }, 
+                    "config": {
+                        "maximum-paths": 0
+                    }
+                }, 
+                "ebgp": {
+                    "state": {
+                        "allow-multiple-as": false, 
+                        "maximum-paths": 0
+                    }, 
+                    "config": {
+                        "allow-multiple-as": false, 
+                        "maximum-paths": 0
+                    }
+                }, 
+                "state": {
+                    "enabled": false
+                }, 
+                "config": {
+                    "enabled": false
+                }
+            }, 
+            "route-selection-options": {
+                "state": {
+                    "enable-aigp": false, 
+                    "ignore-as-path-length": false, 
+                    "advertise-inactive-routes": false, 
+                    "ignore-next-hop-igp-metric": false, 
+                    "always-compare-med": false, 
+                    "external-compare-router-id": false
+                }, 
+                "config": {
+                    "enable-aigp": false, 
+                    "ignore-as-path-length": false, 
+                    "advertise-inactive-routes": false, 
+                    "ignore-next-hop-igp-metric": false, 
+                    "always-compare-med": false, 
+                    "external-compare-router-id": false
+                }
+            }, 
+            "confederation": {
+                "state": {
+                    "identifier": 0, 
+                    "enabled": false, 
+                    "member-as": []
+                }, 
+                "config": {
+                    "identifier": 0, 
+                    "enabled": false, 
+                    "member-as": []
+                }
+            }, 
+            "default-route-distance": {
+                "state": {
+                    "external-route-distance": 0, 
+                    "internal-route-distance": 0
+                }, 
+                "config": {
+                    "external-route-distance": 0, 
+                    "internal-route-distance": 0
+                }
+            }
+        }
+    }
+}

--- a/tests/serialise/juniper-json-examples/run.py
+++ b/tests/serialise/juniper-json-examples/run.py
@@ -48,6 +48,8 @@ def main():
                   (OC + "bgp/openconfig-bgp-neighbor.yang", "openconfig"),
                   (OC + "bgp/openconfig-bgp-peer-group.yang", "openconfig"),
                   (OC + "bgp/openconfig-bgp-policy.yang", "openconfig"),
+                  (OC + "types/openconfig-inet-types.yang", "include"),
+                  (OC + "types/openconfig-yang-types.yang", "include"),
                   (OC + "bgp/openconfig-bgp-types.yang", "include"),
                   (OC + "bgp/openconfig-bgp.yang", "openconfig"),
                   (OC + "policy/openconfig-routing-policy.yang", "openconfig"),


### PR DESCRIPTION
```
- (M) pyangbind/lib/serialise.py:
    - Ensure that decimals are properly encoded when they do not
      carry specific class mapping information (fixes #109).
 - (A) tests/integration/openconfig-bgp/*
    - Add test cases that ensure that an OpenConfig BGP instance is
      serialised as expected.
 - (M) tests/integration/openconfig-interfaces/run.py
    - Fix test case failure due to changes in upstream public models.
 - (M) tests/serialise/juniper-json-examples/run.py
    - Fix test case failure due to changes in upstream public models.
```