### PR TITLE
Fixing bug with empty type.

### DIFF
--- a/pyangbind/lib/serialise.py
+++ b/pyangbind/lib/serialise.py
@@ -462,7 +462,8 @@ class pybindJSONDecoder(object):
         if chk._is_keyval is True:
           pass
         elif chk._yang_type == "empty":
-          if d[key] == None:
+          if d[key] == [None]:
+            set_method = getattr(obj, "_set_%s" % safe_name(ykey), None)
             set_method(True)
         else:
           set_method = getattr(obj, "_set_%s" % safe_name(ykey), None)

--- a/requirements.DEVELOPER.txt
+++ b/requirements.DEVELOPER.txt
@@ -1,2 +1,3 @@
 wheel
 requests
+jsondiff

--- a/tests/serialise/ietf-json-deserialise/run.py
+++ b/tests/serialise/ietf-json-deserialise/run.py
@@ -4,6 +4,7 @@ import os
 import sys
 import getopt
 import json
+from jsondiff import diff
 from pyangbind.lib.serialise import pybindJSONDecoder
 from pyangbind.lib.pybindJSON import dumps
 from bitarray import bitarray
@@ -94,6 +95,7 @@ def main():
             "uint16": 1,
             "union-list": [16, "chicken"],
             "uint32": 1,
+            "empty": True,
             "int32": 1,
             "int16": 1,
             "string": "bear",
@@ -127,8 +129,9 @@ def main():
       }
     }
   }
-  assert nobj.get(filter=True) == expected_get, "Deserialisation of " + \
-    "complete object not as expected"
+  actual_get = nobj.get(filter=True)
+  assert actual_get == expected_get, "Deserialisation of " + \
+    "complete object not as expected. Actual: %s\nExpected: %s\n\nDiff:%s" % (actual_get, expected_get, diff(actual_get, expected_get))
 
   pth = os.path.join(this_dir, "json", "nonexistkey.json")
   for i in [True, False]:


### PR DESCRIPTION
load_ietf_json was not properly handling the empty type. You can tell that it was never called because set_method was being called, but it hadn't been defined yet.

This change checks for [None] instead of None.

I had to update the existing test to include the now-included {'empty': True} part of the expected dictionary. I included some debugging with jsondiff for when the JSON doesn't match, but could remove that if you'd prefer.