### PR TITLE
Using OrderedDict by default as some devices need ordering

### DIFF
--- a/pyangbind/lib/serialise.py
+++ b/pyangbind/lib/serialise.py
@@ -54,7 +54,7 @@ class pybindJSONEncoder(json.JSONEncoder):
         for k in d:
             if isinstance(d[k], dict) or isinstance(d[k], OrderedDict):
                 nd[k] = self._preprocess_element(d[k], mode=mode)
-                if isinstance(d, OrderedDict):
+                if getattr(d, "_user_ordered", False):
                     nd[k]['__yang_order'] = index
             else:
                 nd[k] = self.default(d[k], mode=mode)

--- a/pyangbind/lib/yangtypes.py
+++ b/pyangbind/lib/yangtypes.py
@@ -468,7 +468,7 @@ def TypedListType(*args, **kwargs):
 def YANGListType(*args, **kwargs):
   """
     Return a type representing a YANG list, with a contained class.
-    A dict or ordered dict is used to store the list, and the
+    An ordered dict is used to store the list, and the
     returned object behaves akin to a dictionary.
 
     Additional checks are performed to ensure that the keys of the
@@ -503,10 +503,10 @@ def YANGListType(*args, **kwargs):
 
     def __init__(self, *args, **kwargs):
       self._ordered = True if user_ordered else False
-      if user_ordered:
-        self._members = collections.OrderedDict()
-      else:
-        self._members = dict()
+      self._members = collections.OrderedDict()
+
+      self._members._user_ordered = True if user_ordered else False
+
       self._keyval = keyname
       if not type(listclass) == type(int):
         raise ValueError("contained class of a YANGList must be a class")
@@ -681,6 +681,12 @@ def YANGListType(*args, **kwargs):
     def keys(self):
       return self._members.keys()
 
+    def items(self):
+      return self._members.items()
+
+    def values(self):
+      return self._members.values()
+
     def _generate_key(self, *args, **kwargs):
       keyargs = None
       if len(args):
@@ -751,7 +757,7 @@ def YANGListType(*args, **kwargs):
         return k
 
     def delete(self, *args, **kwargs):
-      (k, discard) = self._generate_key(*args, **kwargs)
+      (k, _) = self._generate_key(*args, **kwargs)
 
       if self._path_helper:
         current_item = self._members[k]
@@ -793,10 +799,8 @@ def YANGListType(*args, **kwargs):
       return self._members[keystr]
 
     def get(self, filter=False):
-      if user_ordered:
-        d = collections.OrderedDict()
-      else:
-        d = {}
+      d = collections.OrderedDict()
+      d._user_ordered = self._members._user_ordered
       for i in self._members:
         if hasattr(self._members[i], "get"):
           d[i] = self._members[i].get(filter=filter)

--- a/tests/list/run.py
+++ b/tests/list/run.py
@@ -201,8 +201,8 @@ def main():
     err = e
   assert err is None, "Could not remove entry from list with keyword arguments"
 
-  assert test_instance.list_container.list_eight.keys() == ['two twenty',
-      'value one value two'], "Entry remained in list after delete()"
+  expected = ['value one value two', 'two twenty']
+  assert test_instance.list_container.list_eight.keys() == expected, "Entry remained in list after delete()"
 
   err = False
   try:


### PR DESCRIPTION
I am using pyangbind to translate OpenConfig into native configuration and I am running into issues as some devices require ordering when entering IP addresses. For example, the following configuration will fail:

```
interface Ethernet2.1
    encapsulation dot1q vlan 1
    ip address 172.20.0.1/24 secondary
    ip address 192.168.1.1/24
napalm_base.exceptions.MergeConfigException: Error [1000]: CLI command 17 of 40 'ip address 172.20.0.1/24 secondary' failed: could not run command [Primary address must be assigned first]
```

The solution is as simple as using always `OrderedDict` instead of when only `user_ordered = True`.
