### PR TITLE
Add original_module in addition to defining_module

### DIFF
--- a/pyangbind/lib/yangtypes.py
+++ b/pyangbind/lib/yangtypes.py
@@ -881,6 +881,7 @@ def YANGDynClass(*args, **kwargs):
   yang_type = kwargs.pop("yang_type", None)
   namespace = kwargs.pop("namespace", None)
   defining_module = kwargs.pop("defining_module", None)
+  original_module = kwargs.pop("original_module", None)
   load = kwargs.pop("load", None)
   is_config = kwargs.pop("is_config", True)
   has_presence = kwargs.pop("presence", None)
@@ -914,7 +915,7 @@ def YANGDynClass(*args, **kwargs):
                  '_is_leaf', '_is_container', '_extensionsd',
                  '_pybind_base_class', '_extmethods', '_is_keyval',
                  '_register_paths', '_namespace', '_yang_type',
-                 '_defining_module', '_metadata', '_is_config', '_cpresent',
+                 '_defining_module', '_original_module', '_metadata', '_is_config', '_cpresent',
                  '_presence']
 
   if extmethods:
@@ -968,6 +969,7 @@ def YANGDynClass(*args, **kwargs):
       self._namespace = namespace
       self._yang_type = yang_type
       self._defining_module = defining_module
+      self._original_module = original_module
       self._metadata = {}
       self._presence = has_presence
       self._cpresent = False

--- a/pyangbind/plugin/pybind.py
+++ b/pyangbind/plugin/pybind.py
@@ -945,6 +945,7 @@ def get_children(ctx, fd, i_children, module, parent, path=str(),
           class_str["arg"] += ", is_keyval=True"
         class_str["arg"] += ", namespace='%s'" % i["namespace"]
         class_str["arg"] += ", defining_module='%s'" % i["defining_module"]
+        class_str["arg"] += ", original_module='%s'" % i["original_module"]
         class_str["arg"] += ", yang_type='%s'" % i["origtype"]
         class_str["arg"] += ", is_config=%s" % (i["config"] and parent_cfg)
         classes[i["name"]] = class_str
@@ -1336,6 +1337,11 @@ def get_element(ctx, fd, element, module, parent, path,
                   None
   defining_module = element_module.arg
 
+  if hasattr(element, "i_orig_module"):
+    original_module = element.i_orig_module.arg
+  else:
+    original_module = defining_module
+
   this_object = []
   default = False
   has_children = False
@@ -1399,6 +1405,7 @@ def get_element(ctx, fd, element, module, parent, path,
           "register_paths": register_paths,
           "namespace": namespace,
           "defining_module": defining_module,
+          "original_module": element.i_orig_module.arg,
           "extensions": extensions if len(extensions) else None,
           "presence": has_presence,
       }
@@ -1611,7 +1618,8 @@ def get_element(ctx, fd, element, module, parent, path,
         "choice": choice,
         "register_paths": register_paths,
         "namespace": namespace,
-        "defining_module": defining_module
+        "defining_module": defining_module,
+        "original_module": element.i_orig_module.arg,
     }
     if len(extensions):
       elemdict["extensions"] = extensions
@@ -1622,3 +1630,4 @@ def get_element(ctx, fd, element, module, parent, path,
 
     this_object.append(elemdict)
   return this_object
+


### PR DESCRIPTION
When a YANG module uses a grouping from another module, `defining_module` is set as the module of the "importer". For those cases, `original_module` will keep the information of the module where the imported grouping was defined for reference.

For example, the grouping `bgp-top`, when used by `network_instances/network_instance[key]/protocols/protocol[key]` will have:

* `defining_module='openconfig-network-instance'`
* `original_module='openconfig-bgp'`