### PR TITLE
Fix #151 load_ietf_json properly yang empty types

### DIFF
--- a/pyangbind/lib/serialise.py
+++ b/pyangbind/lib/serialise.py
@@ -466,19 +466,21 @@ class pybindJSONDecoder(object):
         chk = get_method()
         if chk._is_keyval is True:
           pass
-        elif chk._yang_type == "empty":
-          if d[key] == None:
+        else:
+          val = d[key]
+          if chk._yang_type == "empty":
+            # A 'none' value in the JSON means that an empty value is set, 
+            # since this is serialised as [null] in the input JSON.
+            if val is None:
+              val = True
+            else:
+              val = None  # Ignore an input value different than null/empty
+          if val is not None:
             set_method = getattr(obj, "_set_%s" % safe_name(ykey), None)
             if set_method is None:
               raise AttributeError("Invalid attribute specified in JSON - %s"
                                       % (ykey))
-            set_method(True)
-        else:
-          set_method = getattr(obj, "_set_%s" % safe_name(ykey), None)
-          if set_method is None:
-            raise AttributeError("Invalid attribute specified in JSON - %s"
-                                    % (ykey))
-          set_method(d[key])
+            set_method(d[key])
         pybindJSONDecoder.check_metadata_add(key, d, get_method())
     return obj
 

--- a/pyangbind/lib/serialise.py
+++ b/pyangbind/lib/serialise.py
@@ -468,6 +468,10 @@ class pybindJSONDecoder(object):
           pass
         elif chk._yang_type == "empty":
           if d[key] == None:
+            set_method = getattr(obj, "_set_%s" % safe_name(ykey), None)
+            if set_method is None:
+              raise AttributeError("Invalid attribute specified in JSON - %s"
+                                      % (ykey))
             set_method(True)
         else:
           set_method = getattr(obj, "_set_%s" % safe_name(ykey), None)

--- a/pyangbind/lib/serialise.py
+++ b/pyangbind/lib/serialise.py
@@ -471,16 +471,17 @@ class pybindJSONDecoder(object):
           if chk._yang_type == "empty":
             # A 'none' value in the JSON means that an empty value is set, 
             # since this is serialised as [null] in the input JSON.
-            if val is None:
+            if val == [None]:
               val = True
             else:
-              val = None  # Ignore an input value different than null/empty
+              raise ValueError("Invalid value for empty in input JSON " + \
+                      "key: %s, got: %s" % (ykey, val))
           if val is not None:
             set_method = getattr(obj, "_set_%s" % safe_name(ykey), None)
             if set_method is None:
               raise AttributeError("Invalid attribute specified in JSON - %s"
                                       % (ykey))
-            set_method(d[key])
+            set_method(val)
         pybindJSONDecoder.check_metadata_add(key, d, get_method())
     return obj
 

--- a/tests/serialise/ietf-json-deserialise/run.py
+++ b/tests/serialise/ietf-json-deserialise/run.py
@@ -106,7 +106,8 @@ def main():
             "remote-identityref": "remote:stilton",
             "int64": 1,
             "restricted-string": "aardvark",
-            "decimal": Decimal('16.32')
+            "decimal": Decimal('16.32'),
+            "empty": True,
           }
       },
       "l2": OrderedDict(
@@ -128,7 +129,8 @@ def main():
     }
   }
   assert nobj.get(filter=True) == expected_get, "Deserialisation of " + \
-    "complete object not as expected"
+          "complete object not as expected, got: %s" % \
+          dumps(nobj.get(filter=True), indent=4, mode="ietf")
 
   pth = os.path.join(this_dir, "json", "nonexistkey.json")
   for i in [True, False]:

--- a/tests/serialise/ietf-json-serialise/json/obj.json
+++ b/tests/serialise/ietf-json-serialise/json/obj.json
@@ -53,7 +53,7 @@
                     "chicken"
                 ], 
                 "uint32": 1, 
-                "empty": null, 
+                "empty": [null], 
                 "int32": 1, 
                 "int16": 1, 
                 "string": "bear", 

--- a/tests/serialise/ietf-json-serialise/json/obj.json
+++ b/tests/serialise/ietf-json-serialise/json/obj.json
@@ -53,9 +53,7 @@
                     "chicken"
                 ], 
                 "uint32": 1, 
-                "empty": [
-                    null
-                ], 
+                "empty": null, 
                 "int32": 1, 
                 "int16": 1, 
                 "string": "bear", 

--- a/tests/serialise/ietf-json-serialise/run.py
+++ b/tests/serialise/ietf-json-serialise/run.py
@@ -4,6 +4,7 @@ import os
 import sys
 import getopt
 import json
+import difflib
 from pyangbind.lib.serialise import pybindJSONEncoder, pybindIETFJSONEncoder
 from pyangbind.lib.pybindJSON import dumps
 from decimal import Decimal
@@ -101,7 +102,8 @@ def main():
   external_json = json.load(
                       open(os.path.join(this_dir, "json", "obj.json"), 'r'))
 
-  assert pybind_json == external_json, "JSON did not match the expected output"
+  assert pybind_json == external_json, "JSON did not match the expected output, " + \
+	"diff: %s\n" % diff(pybind_json, external_json)
 
   # Check that we can serialise a single element on its own.
   pybind_json = json.loads(json.dumps(
@@ -112,6 +114,11 @@ def main():
   if not k:
     os.system("/bin/rm %s/bindings.py" % this_dir)
     os.system("/bin/rm %s/bindings.pyc" % this_dir)
+
+def diff(a, b):
+    ja = json.dumps(a, indent=4, sort_keys=True).split("\n")
+    jb = json.dumps(b, indent=4, sort_keys=True).split("\n")
+    return '\n'.join(difflib.unified_diff(ja, jb))
 
 if __name__ == '__main__':
   main()


### PR DESCRIPTION
This intend to solve the problem observed when loading json (load_ietf_json) into an empty yang type object from a null json type value