### PR TITLE
Switch to using regex instead of re

### DIFF
--- a/pyangbind/lib/xpathhelper.py
+++ b/pyangbind/lib/xpathhelper.py
@@ -26,7 +26,7 @@ xpathhelper:
 from collections import OrderedDict
 
 from lxml import etree
-import re
+import regex
 import uuid
 from .yangtypes import safe_name
 from .base import PybindBase
@@ -104,11 +104,11 @@ class FakeRoot(PybindBase):
 
 
 class YANGPathHelper(PybindXpathHelper):
-  _attr_re = re.compile("^(?P<tagname>[^\[]+)(?P<args>(\[[^\]]+\])+)$")
-  _arg_re = re.compile("^((and|or) )?[@]?(?P<cmd>[a-zA-Z0-9\-\_:]+)([ ]+)?" +
+  _attr_re = regex.compile("^(?P<tagname>[^\[]+)(?P<args>(\[[^\]]+\])+)$")
+  _arg_re = regex.compile("^((and|or) )?[@]?(?P<cmd>[a-zA-Z0-9\-\_:]+)([ ]+)?" +
                        "=([ ]+)?[\'\"]?(?P<arg>[^ ^\'^\"]+)([\'\"])?([ ]+)?" +
                        "(?P<remainder>.*)")
-  _relative_path_re = re.compile("^(\.|\.\.)")
+  _relative_path_re = regex.compile("^(\.|\.\.)")
 
   def __init__(self):
     # Initialise an empty library and a new FakeRoot class to act as the
@@ -174,7 +174,7 @@ class YANGPathHelper(PybindXpathHelper):
         for k, v in attributes.iteritems():
           # handling for rfc6020 current() specification
           if "current()" in v:
-            remaining_path = re.sub("current\(\)(?P<remaining>.*)",
+            remaining_path = regex.sub("current\(\)(?P<remaining>.*)",
                                       '\g<remaining>', v).split("/")
             # since the calling leaf may not exist, we need to do a
             # lookup on a path that will do, which is the parent
@@ -227,7 +227,7 @@ class YANGPathHelper(PybindXpathHelper):
     if isinstance(object_path, str):
       raise XPathError("not meant to receive strings as input to register()")
 
-    if re.match('^\.\.', object_path[0]):
+    if regex.match('^\.\.', object_path[0]):
       raise XPathError("unhandled relative path in register()")
 
     # This is a hack to register anything that is a top-level object,
@@ -279,7 +279,7 @@ class YANGPathHelper(PybindXpathHelper):
   def unregister(self, object_path, caller=False):
     if isinstance(object_path, str):
       raise XPathError("should not receive paths as a str in unregister()")
-    if re.match("^(\.|\.\.|\/)", object_path[0]):
+    if regex.match("^(\.|\.\.|\/)", object_path[0]):
       raise XPathError("unhandled relative path in unregister()")
 
     existing_objs = self._get_etree(object_path)

--- a/pyangbind/lib/yangtypes.py
+++ b/pyangbind/lib/yangtypes.py
@@ -24,7 +24,7 @@ from __future__ import unicode_literals
 from decimal import Decimal
 from bitarray import bitarray
 import uuid
-import re
+import regex
 import collections
 import copy
 import six
@@ -32,7 +32,7 @@ import six
 # For Python3
 if six.PY3:
   unicode = str
-
+  basestring = str
 # Words that could turn up in YANG definition files that are actually
 # reserved names in Python, such as being builtin types. This list is
 # not complete, but will probably continue to grow.
@@ -139,7 +139,7 @@ def RestrictedClassType(*args, **kwargs):
   # this gives deserialisers some hints as to how to encode/decode this value
   # it must be a list since a restricted class can encapsulate a restricted
   # class
-  current_restricted_class_type = re.sub("<(type|class) '(?P<class>.*)'>",
+  current_restricted_class_type = regex.sub("<(type|class) '(?P<class>.*)'>",
                                           "\g<class>", str(base_type))
   if hasattr(base_type, "_restricted_class_base"):
     restricted_class_hint = getattr(base_type, "_restricted_class_base")
@@ -179,9 +179,9 @@ def RestrictedClassType(*args, **kwargs):
         _restriction_test method so that it can be called by other functions.
       """
 
-      range_regex = re.compile("(?P<low>\-?[0-9\.]+|min)([ ]+)?\.\.([ ]+)?" +
+      range_regex = regex.compile("(?P<low>\-?[0-9\.]+|min)([ ]+)?\.\.([ ]+)?" +
                                 "(?P<high>(\-?[0-9\.]+|max))")
-      range_single_value_regex = re.compile("(?P<value>\-?[0-9\.]+)")
+      range_single_value_regex = regex.compile("(?P<value>\-?[0-9\.]+)")
 
       def convert_regexp(pattern):
 
@@ -203,6 +203,7 @@ def RestrictedClassType(*args, **kwargs):
           pattern = "^%s" % pattern
         if not pattern[len(pattern) - 1] == "$":
           pattern = "%s$" % pattern
+
         return pattern
 
       def build_length_range_tuples(range, length=False, multiplier=1):
@@ -253,7 +254,7 @@ def RestrictedClassType(*args, **kwargs):
         def mp_check(value):
           if not isinstance(value, basestring):
             return False
-          if re.match(convert_regexp(regexp), value):
+          if regex.match(convert_regexp(regexp), value):
             return True
           return False
         return mp_check
@@ -947,7 +948,7 @@ def YANGDynClass(*args, **kwargs):
     if yang_type in ["container", "list"] or is_container == "container":
       __slots__ = tuple(clsslots)
 
-    _pybind_base_class = re.sub("<(type|class) '(?P<class>.*)'>", "\g<class>",
+    _pybind_base_class = regex.sub("<(type|class) '(?P<class>.*)'>", "\g<class>",
                                   str(base_type))
 
     def __new__(self, *args, **kwargs):
@@ -1211,7 +1212,7 @@ def ReferenceType(*args, **kwargs):
 
           if value is not None:
             set_method(value)
-          self._type = re.sub("<(type|class) '(?P<class>.*)'>", "\g<class>",
+          self._type = regex.sub("<(type|class) '(?P<class>.*)'>", "\g<class>",
                                   str(get_method()._base_type))
 
           self._utype = get_method()._base_type

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 pyang
 bitarray
 lxml
+regex
 six
 enum34

--- a/tests/serialise/openconfig-serialise/run.py
+++ b/tests/serialise/openconfig-serialise/run.py
@@ -6,7 +6,7 @@ import getopt
 import json
 import requests
 import time
-import re
+import regex
 import difflib
 
 from pyangbind.lib.xpathhelper import YANGPathHelper
@@ -94,7 +94,7 @@ def main():
 
   for fn in os.listdir(os.path.join(this_dir, "json")):
     jobj = json.load(open(os.path.join(this_dir, "json", fn), 'r'))
-    parameters = re.sub(
+    parameters = regex.sub(
       'interfaces\_ph:(?P<pathhelper>[a-zA-Z]+)\-flt:(?P<filter>[a-zA-Z]+)\-m:(?P<mode>[a-zA-Z]+)\.json',
       '\g<pathhelper>||\g<filter>||\g<mode>', fn).split("||")
     path_helper, config_filter, mode = YANGBool(parameters[0]), YANGBool(parameters[1]), parameters[2]


### PR DESCRIPTION
This is some of the work done by @dbarrosop in the Python 3 compatibility effort. I've split it out in the continuing effort to trim down the scope of that PR.

I also found a couple more uses of the `re` library, which I updated to use `regex` instead.