### PR TITLE
Improve the handling of strings and unicode

### DIFF
--- a/pyangbind/lib/pybindJSON.py
+++ b/pyangbind/lib/pybindJSON.py
@@ -52,7 +52,7 @@ def loads(d, parent_pymod, yang_base, path_helper=None, extmethods=None,
   # that this really expected a dict, so this check simply makes sure
   # that if the user really did give us a string, we're happy with that
   # without breaking other code.
-  if isinstance(d, six.string_types):
+  if isinstance(d, six.string_types + (six.text_type,)):
     d = json.loads(d, object_pairs_hook=OrderedDict)
   return pybindJSONDecoder.load_json(d, parent_pymod, yang_base,
           path_helper=path_helper, extmethods=extmethods, overwrite=overwrite)
@@ -61,7 +61,7 @@ def loads(d, parent_pymod, yang_base, path_helper=None, extmethods=None,
 def loads_ietf(d, parent_pymod, yang_base, path_helper=None,
                 extmethods=None, overwrite=False):
   # Same as above, to allow for load_ietf to work the same way
-  if isinstance(d, six.string_types):
+  if isinstance(d, six.string_types + (six.text_type,)):
     d = json.loads(d, object_pairs_hook=OrderedDict)
   return pybindJSONDecoder.load_ietf_json(d, parent_pymod, yang_base,
           path_helper=path_helper, extmethods=extmethods, overwrite=overwrite)

--- a/pyangbind/lib/pybindJSON.py
+++ b/pyangbind/lib/pybindJSON.py
@@ -19,16 +19,13 @@ limitations under the License.
 """
 from __future__ import unicode_literals
 
+import copy
+import json
 from collections import OrderedDict
 
-from pyangbind.lib.serialise import pybindJSONEncoder, pybindJSONDecoder, pybindJSONIOError
-from pyangbind.lib.serialise import pybindIETFJSONEncoder
-import json
-import copy
 import six
 
-if six.PY3:
-  unicode = str
+from pyangbind.lib.serialise import pybindIETFJSONEncoder, pybindJSONDecoder, pybindJSONEncoder, pybindJSONIOError
 
 
 def remove_path(tree, path):
@@ -55,7 +52,7 @@ def loads(d, parent_pymod, yang_base, path_helper=None, extmethods=None,
   # that this really expected a dict, so this check simply makes sure
   # that if the user really did give us a string, we're happy with that
   # without breaking other code.
-  if isinstance(d, unicode) or isinstance(d, str):
+  if isinstance(d, six.string_types):
     d = json.loads(d, object_pairs_hook=OrderedDict)
   return pybindJSONDecoder.load_json(d, parent_pymod, yang_base,
           path_helper=path_helper, extmethods=extmethods, overwrite=overwrite)
@@ -64,7 +61,7 @@ def loads(d, parent_pymod, yang_base, path_helper=None, extmethods=None,
 def loads_ietf(d, parent_pymod, yang_base, path_helper=None,
                 extmethods=None, overwrite=False):
   # Same as above, to allow for load_ietf to work the same way
-  if isinstance(d, unicode) or isinstance(d, str):
+  if isinstance(d, six.string_types):
     d = json.loads(d, object_pairs_hook=OrderedDict)
   return pybindJSONDecoder.load_ietf_json(d, parent_pymod, yang_base,
           path_helper=path_helper, extmethods=extmethods, overwrite=overwrite)
@@ -141,14 +138,13 @@ def dumps(obj, indent=4, filter=True, skip_subtrees=[], select=False,
     for t in tree:
       keep = True
       for k, v in select.iteritems():
+        v = six.text_type(v)
         if mode == 'default' or isinstance(tree, dict):
-          if keep and not \
-                unicode(lookup_subdict(tree[t], k.split("."))) == unicode(v):
+          if (keep and not six.text_type(lookup_subdict(tree[t], k.split("."))) == v):
             keep = False
         else:
           # handle ietf case where we have a list and might have namespaces
-          if keep and not \
-                unicode(lookup_subdict(t, k.split("."))) == unicode(v):
+          if (keep and not six.text_type(lookup_subdict(t, k.split("."))) == v):
             keep = False
       if not keep:
         key_del.append(t)

--- a/pyangbind/lib/serialise.py
+++ b/pyangbind/lib/serialise.py
@@ -151,7 +151,7 @@ class pybindJSONEncoder(json.JSONEncoder):
       for k, v in obj.iteritems():
         ndict[k] = self.default(v, mode=mode)
       return ndict
-    elif isinstance(obj, six.string_types):
+    elif isinstance(obj, six.string_types + (six.text_type,)):
       return six.text_type(obj)
     elif isinstance(obj, six.integer_types):
       return int(obj)

--- a/pyangbind/lib/xpathhelper.py
+++ b/pyangbind/lib/xpathhelper.py
@@ -308,7 +308,7 @@ class YANGPathHelper(PybindXpathHelper):
     return retr_obj
 
   def get(self, object_path, caller=False):
-    if isinstance(object_path, six.string_types):
+    if isinstance(object_path, six.string_types + (six.text_type,)):
       object_path = self._path_parts(object_path)
 
     return [self._library[i.get("obj_ptr")]
@@ -327,7 +327,7 @@ class YANGPathHelper(PybindXpathHelper):
 
   def get_list(self, object_path, caller=False,
                 exception_to_raise=YANGPathHelperException):
-    if isinstance(object_path, six.string_types):
+    if isinstance(object_path, six.string_types + (six.text_type,)):
       object_path = self._path_parts(object_path)
 
     parent_obj = self.get_unique(object_path[:-1], caller=caller,

--- a/pyangbind/lib/xpathhelper.py
+++ b/pyangbind/lib/xpathhelper.py
@@ -23,13 +23,17 @@ xpathhelper:
   This module maintains an XML ElementTree for the registered Python
   classes, so that XPATH can be used to lookup particular items.
 """
+from __future__ import unicode_literals
+
+import uuid
 from collections import OrderedDict
 
-from lxml import etree
 import regex
-import uuid
-from .yangtypes import safe_name
+import six
+from lxml import etree
+
 from .base import PybindBase
+from .yangtypes import safe_name
 
 
 class YANGPathHelperException(Exception):
@@ -304,7 +308,7 @@ class YANGPathHelper(PybindXpathHelper):
     return retr_obj
 
   def get(self, object_path, caller=False):
-    if isinstance(object_path, str) or isinstance(object_path, unicode):
+    if isinstance(object_path, six.string_types):
       object_path = self._path_parts(object_path)
 
     return [self._library[i.get("obj_ptr")]
@@ -323,7 +327,7 @@ class YANGPathHelper(PybindXpathHelper):
 
   def get_list(self, object_path, caller=False,
                 exception_to_raise=YANGPathHelperException):
-    if isinstance(object_path, str) or isinstance(object_path, unicode):
+    if isinstance(object_path, six.string_types):
       object_path = self._path_parts(object_path)
 
     parent_obj = self.get_unique(object_path[:-1], caller=caller,

--- a/pyangbind/lib/yangtypes.py
+++ b/pyangbind/lib/yangtypes.py
@@ -21,18 +21,15 @@ limitations under the License.
 """
 from __future__ import unicode_literals
 
-from decimal import Decimal
-from bitarray import bitarray
-import uuid
-import regex
 import collections
 import copy
-import six
+import uuid
+from decimal import Decimal
 
-# For Python3
-if six.PY3:
-  unicode = str
-  basestring = str
+import regex
+import six
+from bitarray import bitarray
+
 # Words that could turn up in YANG definition files that are actually
 # reserved names in Python, such as being builtin types. This list is
 # not complete, but will probably continue to grow.
@@ -130,7 +127,7 @@ def RestrictedClassType(*args, **kwargs):
     type of restriction placed on the class, and the restriction_arg gives
     any input data that this function needs.
   """
-  base_type = kwargs.pop("base_type", unicode)
+  base_type = kwargs.pop("base_type", six.text_type)
   restriction_type = kwargs.pop("restriction_type", None)
   restriction_arg = kwargs.pop("restriction_arg", None)
   restriction_dict = kwargs.pop("restriction_dict", None)
@@ -140,7 +137,7 @@ def RestrictedClassType(*args, **kwargs):
   # it must be a list since a restricted class can encapsulate a restricted
   # class
   current_restricted_class_type = regex.sub("<(type|class) '(?P<class>.*)'>",
-                                          "\g<class>", str(base_type))
+                                          "\g<class>", six.text_type(base_type))
   if hasattr(base_type, "_restricted_class_base"):
     restricted_class_hint = getattr(base_type, "_restricted_class_base")
     restricted_class_hint.append(current_restricted_class_type)
@@ -252,7 +249,7 @@ def RestrictedClassType(*args, **kwargs):
 
       def match_pattern_check(regexp):
         def mp_check(value):
-          if not isinstance(value, basestring):
+          if not isinstance(value, six.string_types + six.text_type):
             return False
           if regex.match(convert_regexp(regexp), value):
             return True
@@ -260,7 +257,7 @@ def RestrictedClassType(*args, **kwargs):
         return mp_check
 
       def in_dictionary_check(dictionary):
-        return lambda i: unicode(i) in dictionary
+        return lambda i: six.text_type(i) in dictionary
 
       val = False
       try:
@@ -365,7 +362,7 @@ def TypedListType(*args, **kwargs):
     certain types (specified by allowed_type kwarg to the function)
     can be added to the list.
   """
-  allowed_type = kwargs.pop("allowed_type", unicode)
+  allowed_type = kwargs.pop("allowed_type", six.text_type)
   if not isinstance(allowed_type, list):
     allowed_type = [allowed_type]
 
@@ -409,11 +406,11 @@ def TypedListType(*args, **kwargs):
               tmp = i(v)
               passed = True
               break
-          elif i == unicode and isinstance(v, str):
-            tmp = unicode(v)
+          elif i == six.text_type and isinstance(v, six.string_types + six.text_type):
+            tmp = six.text_type(v)
             passed = True
             break
-          elif i not in [unicode, str]:
+          elif i not in six.string_types + six.text_type:
             # for anything other than string we try
             # and cast. Using things for string or
             # unicode gives us strange results because we get
@@ -584,7 +581,7 @@ def YANGListType(*args, **kwargs):
         # this is a list that does not have a key specified, and hence
         # we generate a uuid that is used as the key, the method then
         # returns the uuid for the upstream process to use
-        k = str(uuid.uuid1())
+        k = six.text_type(uuid.uuid1())
 
       update = False
       if v is not None:
@@ -714,12 +711,12 @@ def YANGListType(*args, **kwargs):
     def _extract_key(self, obj):
       kp = self._keyval.split(" ")
       if len(kp) > 1:
-        ks = unicode()
+        ks = ''
         for k in kp:
           kv = getattr(obj, "_get_%s" % safe_name(k), None)
           if kv is None:
             raise KeyError("Invalid key attribute specified for object")
-          ks += "%s " % unicode(kv())
+          ks += "%s " % six.text_type(kv())
         return ks.rstrip(" ")
       else:
         kv = getattr(obj, "_get_%s" % safe_name(self._keyval), None)
@@ -1176,7 +1173,7 @@ def ReferenceType(*args, **kwargs):
       self._ptr = False
       self._require_instance = require_instance
       self._type = "unicode"
-      self._utype = unicode
+      self._utype = six.text_type
 
       if len(args):
         value = args[0]
@@ -1228,7 +1225,7 @@ def ReferenceType(*args, **kwargs):
             if len(path_chk) == 1 and is_yang_leaflist(path_chk[0]):
               index = 0
               for i in path_chk[0]:
-                if unicode(i) == unicode(value):
+                if six.text_type(i) == six.text_type(value):
                   found = True
                   self._referenced_object = path_chk[0][index]
                   break
@@ -1236,7 +1233,7 @@ def ReferenceType(*args, **kwargs):
             else:
               found = False
               for i in path_chk:
-                if unicode(i) == unicode(value):
+                if six.text_type(i) == six.text_type(value):
                   found = True
                   self._referenced_object = i
 

--- a/pyangbind/lib/yangtypes.py
+++ b/pyangbind/lib/yangtypes.py
@@ -249,7 +249,7 @@ def RestrictedClassType(*args, **kwargs):
 
       def match_pattern_check(regexp):
         def mp_check(value):
-          if not isinstance(value, six.string_types + six.text_type):
+          if not isinstance(value, six.string_types + (six.text_type,)):
             return False
           if regex.match(convert_regexp(regexp), value):
             return True
@@ -406,11 +406,11 @@ def TypedListType(*args, **kwargs):
               tmp = i(v)
               passed = True
               break
-          elif i == six.text_type and isinstance(v, six.string_types + six.text_type):
+          elif i == six.text_type and isinstance(v, six.string_types + (six.text_type,)):
             tmp = six.text_type(v)
             passed = True
             break
-          elif i not in six.string_types + six.text_type:
+          elif i not in six.string_types + (six.text_type,):
             # for anything other than string we try
             # and cast. Using things for string or
             # unicode gives us strange results because we get

--- a/pyangbind/lib/yangtypes.py
+++ b/pyangbind/lib/yangtypes.py
@@ -498,7 +498,7 @@ def YANGListType(*args, **kwargs):
   extensions = kwargs.pop("extensions", None)
 
   class YANGList(object):
-    __slots__ = ('_pybind_generated_by', '_members', '_keyval',
+    __slots__ = ('_members', '_keyval',
                   '_contained_class', '_path_helper', '_yang_keys',
                   '_ordered',)
     _pybind_generated_by = "YANGListType"
@@ -915,7 +915,7 @@ def YANGDynClass(*args, **kwargs):
   clsslots = ['_default', '_mchanged', '_yang_name', '_choice', '_parent',
                  '_supplied_register_path', '_path_helper', '_base_type',
                  '_is_leaf', '_is_container', '_extensionsd',
-                 '_pybind_base_class', '_extmethods', '_is_keyval',
+                 '_extmethods', '_is_keyval',
                  '_register_paths', '_namespace', '_yang_type',
                  '_defining_module', '_metadata', '_is_config', '_cpresent',
                  '_presence']

--- a/pyangbind/plugin/pybind.py
+++ b/pyangbind/plugin/pybind.py
@@ -810,8 +810,8 @@ def get_children(ctx, fd, i_children, module, parent, path=str(),
     # Doing so gives an AttributeError when a user tries to specify something
     # that was not in the model.
     elements_str = "_pyangbind_elements = OrderedDict(["
-    slots_str = "  __slots__ = ('_pybind_generated_by', '_path_helper',"
-    slots_str += " '_yang_name', '_extmethods', "
+    slots_str = "  __slots__ = ('_path_helper',"
+    slots_str += " '_extmethods', "
     for i in elements:
       slots_str += "'__%s'," % i["name"]
       elements_str += "('%s', %s), " % (i["name"], i["name"])

--- a/pyangbind/plugin/pybind.py
+++ b/pyangbind/plugin/pybind.py
@@ -38,6 +38,8 @@ from pyangbind.lib.yangtypes import RestrictedClassType, YANGBool, safe_name
 # Python3 support
 if six.PY3:
   long = int
+else:
+  import codecs
 
 DEBUG = True
 if DEBUG:
@@ -308,7 +310,7 @@ def build_pybind(ctx, modules, fd):
         sys.exit(127)
 
   # Build the common set of imports that all pyangbind files needs
-  ctx.pybind_common_hdr = ""
+  ctx.pybind_common_hdr = "# -*- coding: utf-8 -*-"
   ctx.pybind_common_hdr += "\n"
   ctx.pybind_common_hdr += "from operator import attrgetter\n"
   if ctx.opts.use_xpathhelper:
@@ -683,13 +685,19 @@ def get_children(ctx, fd, i_children, module, parent, path=str(),
       fpath = bpath + "/__init__.py"
     if not os.path.exists(fpath):
       try:
-        nfd = open(fpath, 'w')
+        if six.PY3:
+          nfd = open(fpath, 'w', encoding="utf-8")
+        else:
+          nfd = codecs.open(fpath, 'w', encoding="utf-8")
       except IOError as m:
         raise IOError("could not open pyangbind output file (%s)" % m)
       nfd.write(ctx.pybind_common_hdr)
     else:
       try:
-        nfd = open(fpath, 'a')
+        if six.PY3:
+          nfd = open(fpath, 'a', encoding="utf-8")
+        else:
+          nfd = codecs.open(fpath, 'a', encoding="utf-8")
       except IOError as w:
         raise IOError("could not open pyangbind output file (%s)" % w)
   else:
@@ -776,8 +784,7 @@ def get_children(ctx, fd, i_children, module, parent, path=str(),
     # code that is generated.
     parent_descr = parent.search_one('description')
     if parent_descr is not None:
-      parent_descr = "\n\n  YANG Description: %s" % \
-          parent_descr.arg.decode('utf8').encode('ascii', 'ignore')
+      parent_descr = "\n\n  YANG Description: %s" % parent_descr.arg
     else:
       parent_descr = ""
 

--- a/pyangbind/plugin/pybind.py
+++ b/pyangbind/plugin/pybind.py
@@ -141,7 +141,7 @@ class_map = {
                     int_size=64)
     },
     'string': {
-        "native_type": "unicode",
+        "native_type": "six.text_type",
         "base_type": True,
         "quote_arg": True,
         "pytype": six.text_type
@@ -1052,8 +1052,7 @@ def get_children(ctx, fd, i_children, module, parent, path=str(),
       c_str = classes[i["name"]]
       description_str = ""
       if i["description"]:
-        description_str = "\n\n    YANG Description: %s" \
-            % i["description"].decode('utf-8').encode('ascii', 'ignore')
+        description_str = "\n\n    YANG Description: %s" % i['description']
       nfd.write('''
   def _get_%s(self):
     """
@@ -1267,7 +1266,7 @@ def build_elemtype(ctx, et, prefix=False):
         cls = "leafref"
       else:
         elemtype = {
-            "native_type": "unicode",
+            "native_type": "six.text_type",
             "parent_type": "string",
             "base_type": False,
         }

--- a/pyangbind/plugin/pybind.py
+++ b/pyangbind/plugin/pybind.py
@@ -21,27 +21,23 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-import optparse
-import sys
-import decimal
 import copy
+import decimal
+import optparse
 import os
-from bitarray import bitarray
+import sys
+
 import six
+from bitarray import bitarray
+from pyang import plugin, statements, util
 
-from pyangbind.lib.yangtypes import safe_name, YANGBool, \
-                                  RestrictedClassType
-from pyangbind.helpers.identity import IdentityStore
 import pyangbind.helpers.misc as misc_help
-
-from pyang import plugin
-from pyang import statements
-from pyang import util
+from pyangbind.helpers.identity import IdentityStore
+from pyangbind.lib.yangtypes import RestrictedClassType, YANGBool, safe_name
 
 # Python3 support
 if six.PY3:
   long = int
-  unicode = str
 
 DEBUG = True
 if DEBUG:
@@ -146,7 +142,7 @@ class_map = {
         "native_type": "unicode",
         "base_type": True,
         "quote_arg": True,
-        "pytype": unicode
+        "pytype": six.text_type
     },
     'decimal64': {
         "native_type": "Decimal",
@@ -334,7 +330,6 @@ def build_pybind(ctx, modules, fd):
 if six.PY3:
   import builtins as __builtin__
   long = int
-  unicode = str
 elif six.PY2:
   import __builtin__
 
@@ -472,7 +467,7 @@ def build_identities(ctx, defnd):
   # Add entries to the class_map such that this identity can be referenced by
   # elements that use this identity ref.
   for i in identity_dict:
-    id_type = {"native_type": """RestrictedClassType(base_type=unicode, """ +
+    id_type = {"native_type": """RestrictedClassType(base_type=six.text_type, """ +
                               """restriction_type="dict_key", """ +
                               """restriction_arg=%s,)""" % identity_dict[i],
                 "restriction_argument": identity_dict[i],
@@ -1211,11 +1206,11 @@ def build_elemtype(ctx, et, prefix=False):
     if et.arg == "enumeration":
       enumeration_dict = {}
       for enum in et.search('enum'):
-        enumeration_dict[unicode(enum.arg)] = {}
+        enumeration_dict[six.text_type(enum.arg)] = {}
         val = enum.search_one('value')
         if val is not None:
-          enumeration_dict[unicode(enum.arg)]["value"] = int(val.arg)
-      elemtype = {"native_type": """RestrictedClassType(base_type=unicode, \
+          enumeration_dict[six.text_type(enum.arg)]["value"] = int(val.arg)
+      elemtype = {"native_type": """RestrictedClassType(base_type=six.text_type, \
                                     restriction_type="dict_key", \
                                     restriction_arg=%s,)""" %
                                     (enumeration_dict),

--- a/tests/base.py
+++ b/tests/base.py
@@ -94,7 +94,7 @@ class PyangBindTestCase(unittest.TestCase):
     if cls.split_class_dir:
       del sys.modules[cls.module_name]
       # Remove auto-generated submodules from our system cache
-      for module in sys.modules.keys():
+      for module in list(sys.modules.keys()):
         if module.startswith('%s.' % cls.module_name):
           del sys.modules[module]
       shutil.rmtree(cls._pyang_generated_class_dir)

--- a/tests/leaf-list/run.py
+++ b/tests/leaf-list/run.py
@@ -1,8 +1,12 @@
 #!/usr/bin/env python
-
-import unittest
+from __future__ import unicode_literals
 
 from tests.base import PyangBindTestCase
+
+try:
+  import unittest2 as unittest
+except ImportError:
+  import unittest
 
 
 class LeafListTests(PyangBindTestCase):
@@ -30,12 +34,8 @@ class LeafListTests(PyangBindTestCase):
       "Cannot successfully address an item from the list.")
 
   def test_append_int_to_string_leaflist(self):
-    allowed = True
-    try:
+    with self.assertRaises(ValueError):
       self.leaflist_obj.container.leaflist.append(1)
-    except ValueError:
-      allowed = False
-    self.assertFalse(allowed, "Appended an element to the list erroneously")
 
   def test_getitem(self):
     self.leaflist_obj.container.leaflist.append("itemOne")
@@ -98,24 +98,16 @@ class LeafListTests(PyangBindTestCase):
       "Leaflist assignment did not function correctly")
 
   def test_leaflist_assignment_of_wrong_type(self):
-    allowed = True
-    try:
+    with self.assertRaises(ValueError):
       self.leaflist_obj.container.leaflist = [1, 2]
-    except ValueError:
-      allowed = False
-    self.assertFalse(allowed, "An erroneous value was assigned to the list.")
 
   def test_restricted_string(self):
     self.leaflist_obj.container.listtwo.append("a-valid-string")
     self.assertEqual(len(self.leaflist_obj.container.listtwo), 1, "Restricted lefalist did not function correctly.")
 
   def test_restricted_string_invalid_value(self):
-    allowed = True
-    try:
+    with self.assertRaises(ValueError):
       self.leaflist_obj.container.listtwo.append("broken-string")
-    except ValueError:
-      allowed = False
-    self.assertFalse(allowed, "An erroneous value was assigned to the list (restricted type)")
 
   def test_union_type(self):
     for pair in [(1, True), ("fish", True), ([], False)]:

--- a/tests/misc/misc.yang
+++ b/tests/misc/misc.yang
@@ -6,7 +6,7 @@ module misc {
     contact "A bug reporter";
 
     description
-        "A test module";
+        "Ä ţêśŧ ɱɵđůŀę";
     revision 2014-01-01 {
         description "april-fools";
         reference "fooled-you";

--- a/tests/misc/run.py
+++ b/tests/misc/run.py
@@ -3,6 +3,8 @@ from __future__ import unicode_literals
 
 import unittest
 
+import six
+
 from pyangbind.lib.xpathhelper import YANGPathHelper
 from tests.base import PyangBindTestCase
 
@@ -24,7 +26,7 @@ class MiscTests(PyangBindTestCase):
     a.foo = "stringval"
 
     self.instance.a.append(a)
-    self.assertEqual(unicode(self.instance.a["stringval"].foo), "stringval")
+    self.assertEqual(six.text_type(self.instance.a["stringval"].foo), "stringval")
     self.assertEqual(self.instance.a["stringval"].config.foo, "stringval")
 
   def test_002_checklistkeytype(self):
@@ -34,7 +36,7 @@ class MiscTests(PyangBindTestCase):
     b.bar = "stringvaltwo"
 
     self.instance.b.append(b)
-    self.assertIsInstance(self.instance.b.keys()[0], unicode)
+    self.assertIsInstance(self.instance.b.keys()[0], six.text_type)
 
   def test_003_checklistkeytype(self):
     import bindings.c as miscc

--- a/tox.ini
+++ b/tox.ini
@@ -6,6 +6,7 @@ skip_missing_interpreters = True
 setenv =
   PYTHONDONTWRITEBYTECODE=1
 deps = -rrequirements.DEVELOPER.txt
+       -rrequirements.txt
 commands = coverage run setup.py test -q {posargs}
 
 [testenv:flake8]


### PR DESCRIPTION
This will, theoretically, make strings and unicode work uniformly across Python 2 and 3. We also now properly handle utf-8 in YANG files. And in generated code files.

I also did a bit of cleaning up of imports, putting them in standard `isort` order/grouping.

And finally, I included @dbarrosop `__slots__` fixes.