### PR TITLE
Py3 fixes for iteration and optparser

### DIFF
--- a/pyangbind/lib/pybindJSON.py
+++ b/pyangbind/lib/pybindJSON.py
@@ -94,7 +94,7 @@ def dumps(obj, indent=4, filter=True, skip_subtrees=[], select=False,
     if not isinstance(key, list):
       raise AttributeError('keys should be a list')
     unresolved_dict = {}
-    for k, v in dictionary.iteritems():
+    for k, v in six.iteritems(dictionary):
       if ":" in k:
         k = k.split(":")[1]
       unresolved_dict[k] = v
@@ -137,7 +137,7 @@ def dumps(obj, indent=4, filter=True, skip_subtrees=[], select=False,
     key_del = []
     for t in tree:
       keep = True
-      for k, v in select.iteritems():
+      for k, v in six.iteritems(select):
         v = six.text_type(v)
         if mode == 'default' or isinstance(tree, dict):
           if (keep and not six.text_type(lookup_subdict(tree[t], k.split("."))) == v):

--- a/pyangbind/lib/serialise.py
+++ b/pyangbind/lib/serialise.py
@@ -88,7 +88,7 @@ class pybindJSONEncoder(json.JSONEncoder):
       return [self.default(i, mode=mode) for i in obj]
     # Expand dictionaries
     elif isinstance(obj, dict):
-      return {k: self.default(v, mode=mode) for k, v in obj.iteritems()}
+      return {k: self.default(v, mode=mode) for k, v in six.iteritems(obj)}
 
     if pybc is not None:
       # Special cases where the wrapper has an underlying class
@@ -148,7 +148,7 @@ class pybindJSONEncoder(json.JSONEncoder):
       return nlist
     elif isinstance(obj, dict):
       ndict = {}
-      for k, v in obj.iteritems():
+      for k, v in six.iteritems(obj):
         ndict[k] = self.default(v, mode=mode)
       return ndict
     elif isinstance(obj, six.string_types + (six.text_type,)):
@@ -274,7 +274,7 @@ class pybindJSONDecoder(object):
           # Put keys in order:
           okeys = []
           kdict = {}
-          for k, v in d[key].iteritems():
+          for k, v in d[key].iteritems():  # YANGListType.iteritems
             if "__yang_order" not in v:
               # Element is not specified in terms of order, so
               # push to a list that keeps this order
@@ -337,7 +337,7 @@ class pybindJSONDecoder(object):
   def check_metadata_add(key, data, obj):
     keys = [six.text_type(k) for k in data]
     if ("@" + key) in keys:
-      for k, v in data["@" + key].iteritems():
+      for k, v in data["@" + key].iteritems():  # YANGListType.iteritems
         obj._add_metadata(k, v)
 
   @staticmethod
@@ -379,7 +379,7 @@ class pybindJSONDecoder(object):
 
       if key == "@":
         # Handle whole container metadata object
-        for k, v in d[key].iteritems():
+        for k, v in d[key].iteritems():  # YANGListType.iteritems
           obj._add_metadata(k, v)
         continue
       elif "@" in key:
@@ -530,7 +530,7 @@ class pybindIETFJSONEncoder(pybindJSONEncoder):
         d[yname] = [pybindIETFJSONEncoder.generate_element(i,
                       parent_namespace=element._namespace, flt=flt,
                       with_defaults=with_defaults)
-                        for i in element._members.itervalues()]
+                        for i in element.itervalues()]
         if not len(d[yname]):
           del d[yname]
       else:

--- a/pyangbind/lib/xpathhelper.py
+++ b/pyangbind/lib/xpathhelper.py
@@ -175,7 +175,7 @@ class YANGPathHelper(PybindXpathHelper):
 
       if attributes is not None:
         epath += tagname + "["
-        for k, v in attributes.iteritems():
+        for k, v in six.iteritems(attributes):
           # handling for rfc6020 current() specification
           if "current()" in v:
             remaining_path = regex.sub("current\(\)(?P<remaining>.*)",
@@ -277,7 +277,7 @@ class YANGPathHelper(PybindXpathHelper):
 
     added_item = etree.SubElement(parent_o, tagname, obj_ptr=this_obj_id)
     if attributes is not None:
-      for k, v in attributes.iteritems():
+      for k, v in six.iteritems(attributes):
         added_item.set(k, v)
 
   def unregister(self, object_path, caller=False):

--- a/pyangbind/lib/yangtypes.py
+++ b/pyangbind/lib/yangtypes.py
@@ -541,10 +541,10 @@ def YANGListType(*args, **kwargs):
       return True
 
     def iteritems(self):
-      return self._members.iteritems()
+      return six.iteritems(self._members)
 
     def itervalues(self):
-      return self._members.itervalues()
+      return six.itervalues(self._members)
 
     def _key_to_native_key_type(self, k):
       if self._keyval is False:

--- a/pyangbind/plugin/pybind.py
+++ b/pyangbind/plugin/pybind.py
@@ -230,60 +230,58 @@ class PyangBindClass(plugin.PyangPlugin):
       #     preferable when one has large trees being compiled.
       #   * extensions - support for YANG extensions that pyangbind should look
       #     for, and add as a dictionary with each element.
-      optlist = [
-          optparse.make_option("--use-xpathhelper",
-                               dest="use_xpathhelper",
-                               action="store_true",
-                               help="""Use the xpathhelper module to
-                                       resolve leafrefs"""),
-          optparse.make_option("--split-class-dir",
-                               metavar="DIR",
-                               dest="split_class_dir",
-                               help="""Split the code output into
-                                       multiple directories"""),
-          optparse.make_option("--interesting-extension",
-                              metavar="EXTENSION-MODULE",
-                              default=[],
-                              action="append",
-                              type=str,
-                              dest="pybind_interested_exts",
-                              help="""A set of extensions that
-                                      are interesting and should be
-                                      stored with the class. They
-                                      can be accessed through the
-                                      "extension_dict()" argument.
-                                      Multiple arguments can be
-                                      specified."""),
-          optparse.make_option("--use-extmethods",
-                              dest="use_extmethods",
-                              action="store_true",
-                              help="""Allow a path-keyed dictionary
-                                      to be used to specify methods
-                                      related to a particular class"""),
-          optparse.make_option("--build-rpcs",
-                              dest="build_rpcs",
-                              action="store_true",
-                              help="""Generate class bindings for
-                                      the input and output of RPCs
-                                      defined in each module. These
-                                      are placed at the root of
-                                      each module"""),
-          optparse.make_option("--presence",
-                                dest="generate_presence",
-                                action="store_true",
-                                help="""Capture whether the presence
-                                        keyword is used in the generated
-                                        code."""),
-          optparse.make_option("--build-notifications",
-                              dest="build_notifications",
-                              action="store_true",
-                              help="""Generate class bindings for
-                                      notifications defined in each
-                                      module. These are placed at
-                                      the root of each module"""),
-      ]
-      g = optparser.add_option_group("pyangbind output specific options")
-      g.add_options(optlist)
+      option_group = optparse.OptionGroup(optparser, "pyangbind output specific options")
+      option_group.add_option("--use-xpathhelper",
+                           dest="use_xpathhelper",
+                           action="store_true",
+                           help="""Use the xpathhelper module to
+                                   resolve leafrefs"""),
+      option_group.add_option("--split-class-dir",
+                           metavar="DIR",
+                           dest="split_class_dir",
+                           help="""Split the code output into
+                                   multiple directories"""),
+      option_group.add_option("--interesting-extension",
+                          metavar="EXTENSION-MODULE",
+                          default=[],
+                          action="append",
+                          type=str,
+                          dest="pybind_interested_exts",
+                          help="""A set of extensions that
+                                  are interesting and should be
+                                  stored with the class. They
+                                  can be accessed through the
+                                  "extension_dict()" argument.
+                                  Multiple arguments can be
+                                  specified."""),
+      option_group.add_option("--use-extmethods",
+                          dest="use_extmethods",
+                          action="store_true",
+                          help="""Allow a path-keyed dictionary
+                                  to be used to specify methods
+                                  related to a particular class"""),
+      option_group.add_option("--build-rpcs",
+                          dest="build_rpcs",
+                          action="store_true",
+                          help="""Generate class bindings for
+                                  the input and output of RPCs
+                                  defined in each module. These
+                                  are placed at the root of
+                                  each module"""),
+      option_group.add_option("--presence",
+                            dest="generate_presence",
+                            action="store_true",
+                            help="""Capture whether the presence
+                                    keyword is used in the generated
+                                    code."""),
+      option_group.add_option("--build-notifications",
+                          dest="build_notifications",
+                          action="store_true",
+                          help="""Generate class bindings for
+                                  notifications defined in each
+                                  module. These are placed at
+                                  the root of each module"""),
+      optparser.add_option_group(option_group)
 
 
 # Core function to build the pyangbind output - starting with building the

--- a/tests/int/run.py
+++ b/tests/int/run.py
@@ -184,7 +184,7 @@ class IntTests(PyangBindTestCase):
       'thirtytwo': -2**31,
       'sixtyfour': -2**63,
     }
-    for leaf, value in bounds.iteritems():
+    for leaf, value in bounds.items():
       with self.subTest(leaf=leaf):
         setter = getattr(self.int_obj.int_container, "_set_%s" % leaf)
         allowed = True
@@ -201,7 +201,7 @@ class IntTests(PyangBindTestCase):
       'thirtytwo': -2**31 - 1,
       'sixtyfour': -2**63 - 1,
     }
-    for leaf, value in bounds.iteritems():
+    for leaf, value in bounds.items():
       with self.subTest(leaf=leaf):
         setter = getattr(self.int_obj.int_container, "_set_%s" % leaf)
         allowed = True
@@ -218,7 +218,7 @@ class IntTests(PyangBindTestCase):
       'thirtytwo': 2**31 - 1,
       'sixtyfour': 2**63 - 1,
     }
-    for leaf, value in bounds.iteritems():
+    for leaf, value in bounds.items():
       with self.subTest(leaf=leaf):
         setter = getattr(self.int_obj.int_container, "_set_%s" % leaf)
         allowed = True
@@ -235,7 +235,7 @@ class IntTests(PyangBindTestCase):
       'thirtytwo': 2**31,
       'sixtyfour': 2**63,
     }
-    for leaf, value in bounds.iteritems():
+    for leaf, value in bounds.items():
       with self.subTest(leaf=leaf):
         setter = getattr(self.int_obj.int_container, "_set_%s" % leaf)
         allowed = True

--- a/tests/xpath/04-root/run.py
+++ b/tests/xpath/04-root/run.py
@@ -4,10 +4,10 @@ import json
 import os
 import unittest
 
-from pyangbind.lib.yangtypes import safe_name
-from pyangbind.lib.xpathhelper import YANGPathHelper
-from pyangbind.lib.serialise import pybindJSONDecoder
 import pyangbind.lib.pybindJSON as pbJ
+from pyangbind.lib.serialise import pybindJSONDecoder
+from pyangbind.lib.xpathhelper import YANGPathHelper
+from pyangbind.lib.yangtypes import safe_name
 from tests.base import PyangBindTestCase
 
 
@@ -41,26 +41,28 @@ class XPathRootTests(PyangBindTestCase):
   def test_004_serialise(self):
     self.instance_a.root_tc04_a.a = "emigration"
     self.instance_b.root_tc04_b.b = "alpine-fork"
-    expected_json = json.load(open(os.path.join(os.path.dirname(__file__), "json", "04-serialise.json")))
+    with open(os.path.join(os.path.dirname(__file__), "json", "04-serialise.json")) as fp:
+      expected_json = json.load(fp)
     v = json.loads(pbJ.dumps(self.path_helper.get_unique("/")))
     self.assertEqual(v, expected_json)
 
-    expected_ietf_json = json.load(open(os.path.join(os.path.dirname(__file__), "json", "04b-ietf-serialise.json")))
+    with open(os.path.join(os.path.dirname(__file__), "json", "04b-ietf-serialise.json")) as fp:
+      expected_ietf_json = json.load(fp)
     v = json.loads(pbJ.dumps(self.path_helper.get_unique("/"), mode="ietf"))
     self.assertEqual(v, expected_ietf_json)
 
   def test_005_deserialise(self):
     root = self.path_helper.get_unique("/")
-    fh = open(os.path.join(os.path.dirname(__file__), "json", "05-deserialise.json"), 'r')
-    pybindJSONDecoder.load_json(json.load(fh), None, None, obj=root)
+    with open(os.path.join(os.path.dirname(__file__), "json", "05-deserialise.json"), 'r') as fp:
+      pybindJSONDecoder.load_json(json.load(fp), None, None, obj=root)
     v = json.loads(pbJ.dumps(self.path_helper.get_unique("/")))
     x = json.load(open(os.path.join(os.path.dirname(__file__), "json", "05-deserialise.json"), 'r'))
     self.assertEqual(v, x)
 
   def test_006_ietf_deserialise(self):
     root = self.path_helper.get_unique("/")
-    fh = open(os.path.join(os.path.dirname(__file__), "json", "06-deserialise-ietf.json"), 'r')
-    pybindJSONDecoder.load_ietf_json(json.load(fh), None, None, obj=root)
+    with open(os.path.join(os.path.dirname(__file__), "json", "06-deserialise-ietf.json"), 'r') as fp:
+      pybindJSONDecoder.load_ietf_json(json.load(fp), None, None, obj=root)
     v = json.loads(pbJ.dumps(self.path_helper.get_unique("/"), mode="ietf"))
     x = json.load(open(os.path.join(os.path.dirname(__file__), "json", "06-deserialise-ietf.json"), 'r'))
     self.assertEqual(v, x)


### PR DESCRIPTION
This will, theoretically, make strings and unicode work uniformly across Python 2 and 3. We also now properly handle utf-8 in YANG files. And in generated code files.

I also did a bit of cleaning up of imports, putting them in standard `isort` order/grouping.

And finally, I included @dbarrosop `__slots__` fixes.