### PR TITLE
Include the `openconfig-if-types.yang` in our downloads

### DIFF
--- a/tests/integration/openconfig-interfaces/run.py
+++ b/tests/integration/openconfig-interfaces/run.py
@@ -49,6 +49,7 @@ class OpenconfigInterfacesTests(PyangBindTestCase):
         'interfaces/openconfig-if-ip.yang',
         'interfaces/openconfig-if-ethernet.yang',
         'interfaces/openconfig-if-aggregate.yang',
+        'interfaces/openconfig-if-types.yang',
         'interfaces/openconfig-interfaces.yang',
       ],
     },


### PR DESCRIPTION
This fixes the new issues with Travis/tox builds failing.