### PR TITLE
Fix bug whereby prefixed identityrefs were not deserialised.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ matrix:
   include:
   - python: 3.6
     env: TOXENV=black
-    condition: "$TOXENV = flake8"
+    condition: "$TOXENV = black"
 install:
   - pip install tox tox-travis codecov
 script: tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ matrix:
   include:
   - python: 3.6
     env: TOXENV=black
+    condition: "$TOXENV = flake8"
 install:
   - pip install tox tox-travis codecov
 script: tox

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ Contributions to PyangBind are very welcome, either directly via pull requests, 
 
 To avoid unnecessary discussions about coding style we are currently enforcing it with [black](https://github.com/ambv/black). Before pushing code:
 
-* make sure you are running the correct version of `black` as per `REQUIREMENTS.DEVELOPER.txt`.
+* make sure you are running the correct version of `black` as per `requirements.DEVELOPER.txt`.
 * reformat your code with `black` passing the option `--line-length 119`.
 
 ### Testing

--- a/pyangbind/lib/serialise.py
+++ b/pyangbind/lib/serialise.py
@@ -499,6 +499,15 @@ class pybindJSONDecoder(object):
                             val = True
                         else:
                             raise ValueError("Invalid value for empty in input JSON " "key: %s, got: %s" % (ykey, val))
+
+                    if chk._yang_type == "identityref":
+                        # identityref values in IETF JSON may contain their module name, as a prefix,
+                        # but we don't build identities with these as valid values. If this is the
+                        # case then re-write the value to just be the name of the identity that we
+                        # should know about.
+                        if ":" in val:
+                            _, val = val.split(":", 2)
+
                     if val is not None:
                         set_method = getattr(obj, "_set_%s" % safe_name(ykey), None)
                         if set_method is None:

--- a/pyangbind/lib/serialise.py
+++ b/pyangbind/lib/serialise.py
@@ -506,7 +506,7 @@ class pybindJSONDecoder(object):
                         # case then re-write the value to just be the name of the identity that we
                         # should know about.
                         if ":" in val:
-                            _, val = val.split(":", 2)
+                            _, val = val.split(":", 1)
 
                     if val is not None:
                         set_method = getattr(obj, "_set_%s" % safe_name(ykey), None)

--- a/tests/serialise/ietf-json-deserialise/json/complete-obj.json
+++ b/tests/serialise/ietf-json-deserialise/json/complete-obj.json
@@ -46,7 +46,7 @@
                 "union": "16", 
                 "k1": 1, 
                 "enumeration": "one", 
-                "identityref": "idone", 
+                "identityref": "ietf-json-serialise:idone", 
                 "uint16": 1, 
                 "union-list": [
                     16, 

--- a/tests/serialise/ietf-json-deserialise/run.py
+++ b/tests/serialise/ietf-json-deserialise/run.py
@@ -75,7 +75,7 @@ class IETFJSONDeserialiseTests(PyangBindTestCase):
                         "leafref": "16",
                         "int8": 1,
                         "uint64": 1,
-                        "remote-identityref": "remote:stilton",
+                        "remote-identityref": "stilton",
                         "int64": 1,
                         "restricted-string": "aardvark",
                         "decimal": Decimal("16.32"),

--- a/tests/serialise/roundtrip/remote.yang
+++ b/tests/serialise/roundtrip/remote.yang
@@ -1,0 +1,24 @@
+module remote {
+  yang-version "1";
+  namespace "http://rob.sh/yang/test/serialise/remote";
+  prefix "foo";
+
+  import roundtrip { prefix "rt"; }
+
+  organization "BugReports Inc";
+  contact "A bug reporter";
+
+
+  description
+      "A test module";
+  revision 2014-01-01 {
+      description "april-fools";
+      reference "fooled-you";
+  }
+  
+  identity VALUE_TWO {
+    base rt:BASE;
+  }
+  
+}
+

--- a/tests/serialise/roundtrip/roundtrip.yang
+++ b/tests/serialise/roundtrip/roundtrip.yang
@@ -1,0 +1,26 @@
+module roundtrip {
+  yang-version "1";
+  namespace "http://rob.sh/yang/test/serialise/roundtrip";
+  prefix "foo";
+  organization "BugReports Inc";
+  contact "A bug reporter";
+
+  description
+      "A test module";
+  revision 2014-01-01 {
+      description "april-fools";
+      reference "fooled-you";
+  }
+  
+  identity BASE;
+  identity VALUE_ONE { base BASE; }
+
+  container a {
+    leaf idref {
+      type identityref {
+        base BASE;
+      }
+    }
+  }
+}
+

--- a/tests/serialise/roundtrip/run.py
+++ b/tests/serialise/roundtrip/run.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python
+from __future__ import unicode_literals
+
+import json
+import os.path
+import unittest
+from bitarray import bitarray
+from decimal import Decimal
+
+import pyangbind.lib.pybindJSON as pbJ
+import pyangbind.lib.serialise as pbS
+from pyangbind.lib.serialise import pybindJSONDecoder
+from pyangbind.lib.xpathhelper import YANGPathHelper
+
+from tests.base import PyangBindTestCase
+
+
+class RoundtripTests(PyangBindTestCase):
+    yang_files = ["roundtrip.yang", "remote.yang"]
+    maxDiff = None
+
+    def setUp(self):
+        self.yang_helper = YANGPathHelper()
+        self.rt_obj = self.bindings.roundtrip(path_helper=self.yang_helper)
+
+    def test_ietf_roundtrip_simple(self):
+        self.rt_obj.a.idref = "VALUE_TWO"
+        j = pbJ.dumps(self.rt_obj, mode='ietf')
+        pbS.pybindJSONDecoder.load_ietf_json(json.loads(j), None, None, obj=self.rt_obj)
+
+    def test_roundtrip_simple(self):
+        self.rt_obj.a.idref = "VALUE_TWO"
+        j = pbJ.dumps(self.rt_obj)
+        pbS.pybindJSONDecoder.load_json(json.loads(j), None, None, obj=self.rt_obj)
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/serialise/roundtrip/run.py
+++ b/tests/serialise/roundtrip/run.py
@@ -25,13 +25,14 @@ class RoundtripTests(PyangBindTestCase):
 
     def test_ietf_roundtrip_simple(self):
         self.rt_obj.a.idref = "VALUE_TWO"
-        j = pbJ.dumps(self.rt_obj, mode='ietf')
+        j = pbJ.dumps(self.rt_obj, mode="ietf")
         pbS.pybindJSONDecoder.load_ietf_json(json.loads(j), None, None, obj=self.rt_obj)
 
     def test_roundtrip_simple(self):
         self.rt_obj.a.idref = "VALUE_TWO"
         j = pbJ.dumps(self.rt_obj)
         pbS.pybindJSONDecoder.load_json(json.loads(j), None, None, obj=self.rt_obj)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
```
  * (M) pyangbind/lib/serialise.py
    - When encountering an identityref leaf that has a prefixed
      identity, strip the prefix from the value. The dictionary
      that pyangbind stores internally has unprefixed, and module-prefix
      prefixed paths, but rfc7951 JSON has module-name prefixed paths,
      which led to #199 and #207.
    - Fixes #199
    - Fixes #207
  * (M) tests/serialise/ietf-json-deserialise/json/complete-obj.json
  * (M) tests/serialise/ietf-json-deserialise/run.py
    - Update IETF JSON deserialising testdata to use prefixes.
  * (A) tests/serialise/roundtrip/__init__.py
  * (A) tests/serialise/roundtrip/remote.yang
  * (A) tests/serialise/roundtrip/roundtrip.yang
  * (A) tests/serialise/roundtrip/run.py
    - Add a new roundtrip test to check we can deserialise what we
      serialise. This is very simple currently to reproduce #207.
```