### PR TITLE
Updates json ietf serialization to not prefix a property value that i…

### DIFF
--- a/pyangbind/lib/serialise.py
+++ b/pyangbind/lib/serialise.py
@@ -118,7 +118,9 @@ class pybindJSONEncoder(json.JSONEncoder):
                 try:
                     emod = obj._enumeration_dict[obj]["@module"]
                     if emod != obj._defining_module:
-                        return "%s:%s" % (obj._enumeration_dict[obj]["@module"], obj)
+                        # if not already prefixed with the type namespace
+                        if not obj.startswith('%s:' % emod):
+                            return "%s:%s" % (emod, obj)
                 except KeyError:
                     pass
                 return six.text_type(obj)


### PR DESCRIPTION
…s already prefixed. This can occur when ietf serializing an instance that was deserialized from a json ietf string.  For example...

```
# deserialize from json-ietf
$ aps = pybindJSON.loads_ietf(OC_EXAMPLE_ACCESS_POINTS, openconfig_access_points, "openconfig_access_points")

# serialize to json-ietf
$ pybindJSON.dumps(aps, indent=None, mode='ietf')
```