### PR TITLE
xml-serialisation: fix bug when there is an unset/missing identityref

### DIFF
--- a/pyangbind/lib/serialise.py
+++ b/pyangbind/lib/serialise.py
@@ -359,8 +359,8 @@ class pybindIETFXMLEncoder(object):
     def yname_ns_func(parent_namespace, element, yname):
         # to keeps things simple, we augment every key with a complete namespace map
         ns_map = [(None, element._namespace)]
-        if element._yang_type == "identityref" and element in element._enumeration_dict:
-            # valid identityref (i.e. points to a valid identity)
+        if element._yang_type == "identityref" and element._changed():
+            # configured identityref (i.e. points to a valid identity)
             ns_map.append(
                 (element._enumeration_dict[element]["@module"], element._enumeration_dict[element]["@namespace"])
             )

--- a/pyangbind/lib/serialise.py
+++ b/pyangbind/lib/serialise.py
@@ -359,7 +359,8 @@ class pybindIETFXMLEncoder(object):
     def yname_ns_func(parent_namespace, element, yname):
         # to keeps things simple, we augment every key with a complete namespace map
         ns_map = [(None, element._namespace)]
-        if element._yang_type == "identityref":
+        if element._yang_type == "identityref" and element in element._enumeration_dict:
+            # valid identityref (i.e. points to a valid identity)
             ns_map.append(
                 (element._enumeration_dict[element]["@module"], element._enumeration_dict[element]["@namespace"])
             )

--- a/tests/serialise/xml-serialise/ietf-xml-serialise.yang
+++ b/tests/serialise/xml-serialise/ietf-xml-serialise.yang
@@ -175,7 +175,7 @@ module ietf-xml-serialise {
         }
       }
 
-      leaf missing-identityref {
+      leaf unset-identityref {
         type identityref {
           base id-base;
         }

--- a/tests/serialise/xml-serialise/ietf-xml-serialise.yang
+++ b/tests/serialise/xml-serialise/ietf-xml-serialise.yang
@@ -175,6 +175,12 @@ module ietf-xml-serialise {
         }
       }
 
+      leaf missing-identityref {
+        type identityref {
+          base id-base;
+        }
+      }
+
       leaf remote-identityref {
         type identityref {
           base remote:cheese;

--- a/tests/serialise/xml-serialise/run.py
+++ b/tests/serialise/xml-serialise/run.py
@@ -35,6 +35,8 @@ def xml_tree_equivalence(e1, e2):
         return False
     e1_children = sorted(e1.getchildren(), key=lambda x: x.tag)
     e2_children = sorted(e2.getchildren(), key=lambda x: x.tag)
+    if len(e1_children) != len(e2_children):
+        return False
     return all(xml_tree_equivalence(c1, c2) for c1, c2 in zip(e1_children, e2_children))
 
 


### PR DESCRIPTION
Fixes serialisation bug when an identityref leaf hasn't been assigned a value. See test case.