### PR TITLE
fix: serialisation element ordering for py<3.6

### DIFF
--- a/pyangbind/lib/serialise.py
+++ b/pyangbind/lib/serialise.py
@@ -105,7 +105,7 @@ class YangDataSerialiser(object):
             return [self.default(i) for i in obj]
         # Expand dictionaries
         elif isinstance(obj, dict):
-            return {k: self.default(v) for k, v in six.iteritems(obj)}
+            return OrderedDict((k, self.default(v)) for k, v in six.iteritems(obj))
 
         if pybc is not None:
             # Special cases where the wrapper has an underlying class
@@ -407,7 +407,7 @@ def make_generate_ietf_tree(yname_ns_func):
             # were a scalar.
             return obj
 
-        d = {}
+        d = OrderedDict()
         for element_name in obj._pyangbind_elements:
             element = getattr(obj, element_name, None)
             yang_name = getattr(element, "yang_name", None)


### PR DESCRIPTION
Found an issue where serialised XML output would have incorrect ordering _sometimes_. It turns out I never saw this because I was developing with python 3.6, which features an ordered `dict` implementation.

I have made an update to explicitly use `OrderedDict` instead, so we have the same behaviour for python <3.6.