### PR TITLE
fix a identityref field module name namespace missing issue.

### DIFF
--- a/pyangbind/helpers/identity.py
+++ b/pyangbind/helpers/identity.py
@@ -31,6 +31,8 @@ class Identity(object):
         self.children = []
 
     def add_prefix(self, prefix):
+        if self.source_module not in self._imported_prefixes:
+            self._imported_prefixes.append(self.source_module)
         if prefix not in self._imported_prefixes:
             self._imported_prefixes.append(prefix)
 

--- a/pyangbind/helpers/identity.py
+++ b/pyangbind/helpers/identity.py
@@ -31,8 +31,6 @@ class Identity(object):
         self.children = []
 
     def add_prefix(self, prefix):
-        if self.source_module not in self._imported_prefixes:
-            self._imported_prefixes.append(self.source_module)
         if prefix not in self._imported_prefixes:
             self._imported_prefixes.append(prefix)
 


### PR DESCRIPTION
the issue is: when load identityref field to Yang data tree with module
name as the namespace, when we dump the Yang data to ietf json, the
namespace will lost.

the root cause is: when we generate python code from Yang module, the
restriction_arg for the field doesn't include module name as the prefix.

the fix is: add source_module into the imported_prefixes, so pyangbind can
generate also generate the module name as the namespace for identityref field.