### PR TITLE
Fix _is_config attribute for non-config containers

### DIFF
--- a/pyangbind/plugin/pybind.py
+++ b/pyangbind/plugin/pybind.py
@@ -1463,12 +1463,14 @@ def get_element(ctx, fd, element, module, parent, path, parent_cfg=True, choice=
                 register_paths=register_paths,
             )
 
+            elemconfig = class_bool_map[element.search_one("config").arg] if element.search_one("config") else True
+
             elemdict = {
                 "name": safe_name(element.arg),
                 "origtype": element.keyword,
                 "class": element.keyword,
                 "path": safe_name(npath),
-                "config": True,
+                "config": elemconfig,
                 "description": elemdescr,
                 "yang_name": element.arg,
                 "choice": choice,

--- a/tests/config-false/run.py
+++ b/tests/config-false/run.py
@@ -33,6 +33,9 @@ class ConfigFalseTests(PyangBindTestCase):
             allowed = False
         self.assertFalse(allowed)
 
+    def test_container_reports_not_configurable_with_config_false(self):
+        self.assertFalse(self.test_instance.container.subtwo._is_config)
+
     def test_leaf_reports_not_configurable_with_config_false(self):
         self.assertFalse(self.test_instance.container.subone.d_leaf._is_config)
 
@@ -54,6 +57,9 @@ class ConfigFalseTests(PyangBindTestCase):
         except AttributeError:
             allowed = False
         self.assertFalse(allowed)
+
+    def test_container_in_non_configurable_container_reports_not_configurable(self):
+        self.assertFalse(self.test_instance.container.subtwo.subsubtwo._is_config)
 
     def test_leaf_in_sub_container_of_non_configurable_container_reports_not_configurable(self):
         self.assertFalse(self.test_instance.container.subtwo.subsubtwo.c_leaf._is_config)

--- a/tests/serialise/openconfig-serialise/json/interfaces_ph:False-flt:False-m:default.json
+++ b/tests/serialise/openconfig-serialise/json/interfaces_ph:False-flt:False-m:default.json
@@ -31,7 +31,10 @@
                     "ifindex": 0, 
                     "last-change": 0, 
                     "oper-status": "", 
+                    "logical": false,
                     "counters": {
+                        "in-pkts": 0, 
+                        "out-pkts": 0, 
                         "in-fcs-errors": 0, 
                         "in-errors": 0, 
                         "in-discards": 0, 

--- a/tests/serialise/openconfig-serialise/json/interfaces_ph:False-flt:False-m:ietf.json
+++ b/tests/serialise/openconfig-serialise/json/interfaces_ph:False-flt:False-m:ietf.json
@@ -31,7 +31,10 @@
                     "ifindex": 0, 
                     "last-change": "0", 
                     "oper-status": "", 
+                    "logical": false, 
                     "counters": {
+                        "in-pkts": "0", 
+                        "out-pkts": "0", 
                         "in-fcs-errors": "0", 
                         "in-errors": "0", 
                         "in-discards": "0", 

--- a/tests/serialise/openconfig-serialise/json/interfaces_ph:True-flt:False-m:default.json
+++ b/tests/serialise/openconfig-serialise/json/interfaces_ph:True-flt:False-m:default.json
@@ -32,7 +32,10 @@
                     "ifindex": 0, 
                     "last-change": 0, 
                     "oper-status": "", 
+                    "logical": false, 
                     "counters": {
+                        "in-pkts": 0, 
+                        "out-pkts": 0, 
                         "in-fcs-errors": 0, 
                         "in-errors": 0, 
                         "in-discards": 0, 

--- a/tests/serialise/openconfig-serialise/json/interfaces_ph:True-flt:False-m:ietf.json
+++ b/tests/serialise/openconfig-serialise/json/interfaces_ph:True-flt:False-m:ietf.json
@@ -31,7 +31,10 @@
                     "ifindex": 0, 
                     "last-change": "0", 
                     "oper-status": "", 
+                    "logical": false,
                     "counters": {
+                        "in-pkts": "0", 
+                        "out-pkts": "0", 
                         "in-fcs-errors": "0", 
                         "in-errors": "0", 
                         "in-discards": "0", 


### PR DESCRIPTION
When a YANG definition of a container has the statement "config false;",
the Python bindings generated for this container should have "is_config=False"
in its __init__ method, but it was not the case.

Containers nested in non-config containers correctly inherited the _is_config
attribute from its parent.

Add two test cases to tests/config-false.