### PR TITLE
#227 pybindIETFXMLEncoder fails to serialize the object into XML

### DIFF
--- a/pyangbind/lib/serialise.py
+++ b/pyangbind/lib/serialise.py
@@ -309,7 +309,7 @@ class pybindIETFXMLEncoder(object):
     """
 
     class EMF(objectify.ElementMaker):
-        """Custome ElementMaker class to ease netconf namespace handling"""
+        """Custom ElementMaker class to ease netconf namespace handling"""
 
         def __init__(self, namespace=None, nsmap=None):
             assert namespace or nsmap, "Must set either namespace or nsmap"
@@ -372,7 +372,7 @@ class pybindIETFXMLEncoder(object):
         ietf_tree_xml_func = make_generate_ietf_tree(pybindIETFXMLEncoder.yname_ns_func)
         tree = ietf_tree_xml_func(obj, flt=filter)
         preprocessed = XmlYangDataSerialiser().preprocess_element(tree)
-        return cls.generate_xml_tree(obj._yang_name, obj._yang_namespace, preprocessed)
+        return cls.generate_xml_tree(obj._yang_name, obj._namespace, preprocessed)
 
     @classmethod
     def serialise(cls, obj, filter=True, pretty_print=True):


### PR DESCRIPTION
 - fix for unknown _yang_namespace in robshakir/pyangbind.

also Comment typo fix.