### PR TITLE
Update reserved keywords to support python 3.7

### DIFF
--- a/pyangbind/lib/yangtypes.py
+++ b/pyangbind/lib/yangtypes.py
@@ -84,6 +84,7 @@ reserved_name = [
     "property",
     "min",
     "max",
+    "async",
 ]
 
 


### PR DESCRIPTION
`async` is part of python syntax and need to be handled carefully as part of class generation.