### PR TITLE
fix: change the collections import from `collections` to `six.moves import collections_abc`

### DIFF
--- a/pyangbind/lib/yangtypes.py
+++ b/pyangbind/lib/yangtypes.py
@@ -22,6 +22,7 @@ limitations under the License.
 from __future__ import unicode_literals
 
 import collections
+from six.moves import collections_abc
 import copy
 import uuid
 from decimal import Decimal
@@ -415,7 +416,7 @@ def TypedListType(*args, **kwargs):
     if not isinstance(allowed_type, list):
         allowed_type = [allowed_type]
 
-    class TypedList(collections.MutableSequence):
+    class TypedList(collections_abc.MutableSequence):
         _pybind_generated_by = "TypedListType"
         _list = list()
 


### PR DESCRIPTION
The problem we face is, the collections does no longer include MutableSequence, it is moved to collections_abc.
The six package has a fix for that.
`from six.moves import collections_abc`

This pull request makes the library also usable with python 3.10