### PR TITLE
Python version and linter updates

### DIFF
--- a/pyangbind/helpers/identity.py
+++ b/pyangbind/helpers/identity.py
@@ -21,7 +21,6 @@ from .misc import module_import_prefixes
 
 
 class Identity(object):
-
     def __init__(self, name):
         self.name = name
         self.source_module = None
@@ -47,7 +46,6 @@ class Identity(object):
 
 
 class IdentityStore(object):
-
     def __init__(self):
         self._store = []
 

--- a/pyangbind/lib/base.py
+++ b/pyangbind/lib/base.py
@@ -20,7 +20,6 @@ limitations under the License.
 
 
 class PybindBase(object):
-
     __slots__ = ()
 
     def elements(self):
@@ -30,7 +29,6 @@ class PybindBase(object):
         return str(self.elements())
 
     def get(self, filter=False):
-
         def error():
             return NameError, "element does not exist"
 
@@ -100,7 +98,6 @@ class PybindBase(object):
         return d
 
     def __getitem__(self, k):
-
         def error():
             raise KeyError("Key %s does not exist" % k)
 

--- a/pyangbind/lib/pybindJSON.py
+++ b/pyangbind/lib/pybindJSON.py
@@ -85,7 +85,6 @@ def load_ietf(fn, parent_pymod, yang_module, path_helper=None, extmethods=None, 
 
 
 def dumps(obj, indent=4, filter=True, skip_subtrees=[], select=False, mode="default", with_defaults=None):
-
     def lookup_subdict(dictionary, key):
         if not isinstance(key, list):
             raise AttributeError("keys should be a list")

--- a/pyangbind/lib/serialise.py
+++ b/pyangbind/lib/serialise.py
@@ -58,6 +58,7 @@ class pybindJSONDecodeError(Exception):
 
 class UnmappedItem(Exception):
     """Used to simulate an Optional value"""
+
     pass
 
 
@@ -266,6 +267,7 @@ class _pybindJSONEncoderBase(json.JSONEncoder):
 
     Do not use directly, subclass and set the `serialiser_class` attribute appropriately
     """
+
     serialiser_class = None
 
     def encode(self, obj):
@@ -277,12 +279,14 @@ class _pybindJSONEncoderBase(json.JSONEncoder):
 
 class pybindJSONEncoder(_pybindJSONEncoderBase):
     """Default pybind JSON encoder"""
+
     serialiser_class = YangDataSerialiser
 
 
 class pybindIETFJSONEncoder(_pybindJSONEncoderBase):
     """IETF JSON encoder, we add a special method `generate_element()` that should be used
     to restructure the pybind object to fit IETF requirements prior to JSON encoding."""
+
     serialiser_class = IETFYangDataSerialiser
 
     @staticmethod
@@ -492,7 +496,6 @@ class pybindIETFXMLDecoder(object):
             chobj = attr_get()
 
             if chobj._yang_type == "container":
-
                 if hasattr(chobj, "_presence"):
                     if chobj._presence:
                         chobj._set_present()
@@ -563,12 +566,10 @@ class pybindIETFXMLDecoder(object):
 
 
 class pybindJSONDecoder(object):
-
     @staticmethod
     def load_json(
         d, parent, yang_base, obj=None, path_helper=None, extmethods=None, overwrite=False, skip_unknown=False
     ):
-
         if obj is None:
             # we need to find the class to create, as one has not been supplied.
             base_mod_cls = getattr(parent, safe_name(yang_base))

--- a/pyangbind/lib/xpathhelper.py
+++ b/pyangbind/lib/xpathhelper.py
@@ -49,49 +49,48 @@ class PybindImplementationError(Exception):
 
 
 class PybindXpathHelper(object):
-
     def register(self, path, object_ptr, caller=False):
         """
-      A PybindXpathHelper class should supply a register() method that
-      takes two mandatory arguments, and one optional.
+        A PybindXpathHelper class should supply a register() method that
+        takes two mandatory arguments, and one optional.
 
-      * path - the path to which the object should be registered. This is
-        supplied as a list of the names of the elements of the path. For
-        example, /device/interfaces/interface[name='eth0'] is supplied as
-        a ["device", "interfaces", "interface[@name='eth0']"].
+        * path - the path to which the object should be registered. This is
+          supplied as a list of the names of the elements of the path. For
+          example, /device/interfaces/interface[name='eth0'] is supplied as
+          a ["device", "interfaces", "interface[@name='eth0']"].
 
-      * object_ptr - a reference to the object that is to be stored at this
-        location in the tree.
+        * object_ptr - a reference to the object that is to be stored at this
+          location in the tree.
 
-      * caller=False - this supplies the path of the object that is currently
-        trying to perform a register. In general, it will not be used, but it
-        is supplied to facilitate relative path lookups.
-    """
+        * caller=False - this supplies the path of the object that is currently
+          trying to perform a register. In general, it will not be used, but it
+          is supplied to facilitate relative path lookups.
+        """
         raise PybindImplementationError("The path helper class specified does " + "not implement register()")
 
     def unregister(self, path, caller=False):
         """
-      A PybindXpathHelper class should supply an unregister() method that
-      takes one mandatory argument, and one optional.
+        A PybindXpathHelper class should supply an unregister() method that
+        takes one mandatory argument, and one optional.
 
-      * path - the path of the object to be unregistered. Supplied as a list()
-        object of the elements of the path.
+        * path - the path of the object to be unregistered. Supplied as a list()
+          object of the elements of the path.
 
-      * caller=False - the absolute path of the object calling the unregister()
-        method.
-    """
+        * caller=False - the absolute path of the object calling the unregister()
+          method.
+        """
         raise PybindImplementationError("The path helper class specified does " + "not implement unregister()")
 
     def get(self, path, caller=False):
         """
-      A PybindXpathHelper class should supply a get() method that takes one
-      mandatory argument and one optional.
+        A PybindXpathHelper class should supply a get() method that takes one
+        mandatory argument and one optional.
 
-      * path - the path to the object to be retrieved. This may be specified as
-        a list of parts, or an XPATH expression.
+        * path - the path to the object to be retrieved. This may be specified as
+          a list of parts, or an XPATH expression.
 
-      * caller=False - the absolute path of the object calling the get method.
-    """
+        * caller=False - the absolute path of the object calling the get method.
+        """
         raise PybindImplementationError("The path helper class specified does " + "not implement get()")
 
 

--- a/pyangbind/lib/yangtypes.py
+++ b/pyangbind/lib/yangtypes.py
@@ -120,7 +120,7 @@ def remove_path_attributes(p):
 def safe_name(arg):
     """
     Make a leaf or container name safe for use in Python.
-  """
+    """
     arg = arg.replace("-", "_")
     arg = arg.replace(".", "_")
     if arg in reserved_name:
@@ -134,23 +134,24 @@ def RestrictedPrecisionDecimalType(*args, **kwargs):
     """
     Function to return a new type that is based on decimal.Decimal with
     an arbitrary restricted precision.
-  """
+    """
     precision = kwargs.pop("precision", False)
 
     class RestrictedPrecisionDecimal(Decimal):
         """
-      Class extending decimal.Decimal to restrict the precision that is
-      stored, supporting the fraction-digits argument of the YANG decimal64
-      type.
-    """
+        Class extending decimal.Decimal to restrict the precision that is
+        stored, supporting the fraction-digits argument of the YANG decimal64
+        type.
+        """
+
         _precision = 10.0 ** (-1.0 * int(precision))
         _pybind_generated_by = "RestrictedPrecisionDecimal"
 
         def __new__(self, *args, **kwargs):
             """
-        Overloads the decimal __new__ function in order to round the input
-        value to the new value.
-      """
+            Overloads the decimal __new__ function in order to round the input
+            value to the new value.
+            """
             if self._precision is not None:
                 if len(args):
                     value = Decimal(args[0]).quantize(Decimal(str(self._precision)))
@@ -172,7 +173,7 @@ def RestrictedClassType(*args, **kwargs):
     a specified restriction. The restriction_type specified determines the
     type of restriction placed on the class, and the restriction_arg gives
     any input data that this function needs.
-  """
+    """
     base_type = kwargs.pop("base_type", six.text_type)
     restriction_type = kwargs.pop("restriction_type", None)
     restriction_arg = kwargs.pop("restriction_arg", None)
@@ -191,10 +192,11 @@ def RestrictedClassType(*args, **kwargs):
 
     class RestrictedClass(base_type):
         """
-      A class that restricts the base_type class with a new function that the
-      input value is validated against before being applied. The function is
-      a static method which is assigned to _restricted_test.
-    """
+        A class that restricts the base_type class with a new function that the
+        input value is validated against before being applied. The function is
+        a static method which is assigned to _restricted_test.
+        """
+
         _pybind_generated_by = "RestrictedClassType"
 
         _restricted_class_base = restricted_class_hint
@@ -202,10 +204,10 @@ def RestrictedClassType(*args, **kwargs):
 
         def __init__(self, *args, **kwargs):
             """
-        Overloads the base_class __init__ method to check the input argument
-        against the validation function - returns on instance of the base_type
-        class, which can be manipulated as per a usual Python object.
-      """
+            Overloads the base_class __init__ method to check the input argument
+            against the validation function - returns on instance of the base_type
+            class, which can be manipulated as per a usual Python object.
+            """
             try:
                 self.__check(args[0])
             except IndexError:
@@ -228,7 +230,6 @@ def RestrictedClassType(*args, **kwargs):
             range_single_value_regex = regex.compile("(?P<value>\-?[0-9\.]+)")
 
             def convert_regexp(pattern):
-
                 # Some patterns include a $ character in them in some IANA modules, this
                 # is not escaped. Do some logic to escape them, whilst leaving one at the
                 # end of the string if it's there.
@@ -271,7 +272,6 @@ def RestrictedClassType(*args, **kwargs):
                     raise ValueError("Invalid range or length argument specified")
 
             def in_range_check(low_high_tuples, length=False):
-
                 def range_check(value):
                     if length and isinstance(value, bitarray):
                         value = value.length()
@@ -296,7 +296,6 @@ def RestrictedClassType(*args, **kwargs):
                 return range_check
 
             def match_pattern_check(regexp):
-
                 def mp_check(value):
                     if not isinstance(value, six.string_types + (six.text_type,)):
                         return False
@@ -383,9 +382,9 @@ def RestrictedClassType(*args, **kwargs):
 
         def __check(self, v):
             """
-        Run the _restriction_test static method against the argument v,
-        returning an error if the value does not validate.
-      """
+            Run the _restriction_test static method against the argument v,
+            returning an error if the value does not validate.
+            """
             v = base_type(v)
             for chkfn in self._restriction_tests:
                 if not chkfn(v):
@@ -394,9 +393,9 @@ def RestrictedClassType(*args, **kwargs):
 
         def getValue(self, *args, **kwargs):
             """
-        For types where there is a dict_key restriction (such as YANG
-        enumeration), return the value of the dictionary key.
-      """
+            For types where there is a dict_key restriction (such as YANG
+            enumeration), return the value of the dictionary key.
+            """
             if "dict_key" in self._restriction_dict:
                 value = kwargs.pop("mapped", False)
                 if value:
@@ -411,7 +410,7 @@ def TypedListType(*args, **kwargs):
     Return a type that consists of a list object where only
     certain types (specified by allowed_type kwarg to the function)
     can be added to the list.
-  """
+    """
     allowed_type = kwargs.pop("allowed_type", six.text_type)
     if not isinstance(allowed_type, list):
         allowed_type = [allowed_type]
@@ -538,7 +537,7 @@ def YANGListType(*args, **kwargs):
     Where a list exists that does not have a key - which can be the
     case for 'config false' lists - a uuid is generated and used
     as the key for the list.
-  """
+    """
     try:
         keyname = args[0]
         listclass = args[1]
@@ -888,7 +887,7 @@ class YANGBool(int):
 
     This bool also accepts input matching strings to handle the
     forms that might be used in YANG modules.
-  """
+    """
 
     def __new__(self, *args, **kwargs):
         false_args = ["false", "False", False, 0, "0"]
@@ -935,7 +934,7 @@ def YANGDynClass(*args, **kwargs):
                      node.
       - presence:    Whether the YANG container that is being
                      represented has the presence keyword
-  """
+    """
     base_type = kwargs.pop("base", False)
     default = kwargs.pop("default", False)
     yang_name = kwargs.pop("yang_name", False)
@@ -1198,7 +1197,6 @@ def YANGDynClass(*args, **kwargs):
                 return []
 
         def __generate_extmethod(self, methodfn):
-
             def extmethodfn(*args, **kwargs):
                 kwargs["caller"] = self._register_path()
                 kwargs["path_helper"] = self._path_helper
@@ -1232,14 +1230,13 @@ def ReferenceType(*args, **kwargs):
     to be a relative (rather than absolute) path. The require_instance
     argument specifies whether errors should be thrown in the case
     that the referenced instance does not exist.
-  """
+    """
     ref_path = kwargs.pop("referenced_path", False)
     path_helper = kwargs.pop("path_helper", None)
     caller = kwargs.pop("caller", False)
     require_instance = kwargs.pop("require_instance", False)
 
     class ReferencePathType(object):
-
         __slots__ = (
             "_referenced_path",
             "_path_helper",

--- a/pyangbind/plugin/pybind.py
+++ b/pyangbind/plugin/pybind.py
@@ -192,7 +192,6 @@ def pyang_plugin_init():
 
 
 class PyangBindClass(plugin.PyangPlugin):
-
     def add_output_format(self, fmts):
         # Add the 'pybind' output format to pyang.
         self.multiple_modules = True
@@ -619,7 +618,6 @@ def build_typedefs(ctx, defnd):
             parent_type = []
             default = False if default_stmt is None else default_stmt.arg
             for i in elemtype:
-
                 if isinstance(i[1]["native_type"], list):
                     native_type.extend(i[1]["native_type"])
                 else:
@@ -648,7 +646,6 @@ def build_typedefs(ctx, defnd):
 
 
 def get_children(ctx, fd, i_children, module, parent, path=str(), parent_cfg=True, choice=False, register_paths=True):
-
     # Iterative function that is called for all elements that have childen
     # data nodes in the tree. This function resolves those nodes into the
     # relevant leaf, or container/list configuration and outputs the python

--- a/requirements.DEVELOPER.txt
+++ b/requirements.DEVELOPER.txt
@@ -4,5 +4,4 @@ coverage
 pytest
 requests
 tox
-unittest2; python_version < '3.0'
 wheel

--- a/requirements.DEVELOPER.txt
+++ b/requirements.DEVELOPER.txt
@@ -1,4 +1,4 @@
-black==18.5b0; python_version >= '3.6'
+black
 build
 coverage
 pytest

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,11 +30,11 @@ classifiers =
     Intended Audience :: Developers
     Topic :: Software Development :: Code Generators
     License :: OSI Approved :: Apache Software License
-    Programming Language :: Python :: 2.7
-    Programming Language :: Python :: 3.4
-    Programming Language :: Python :: 3.5
-    Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
     Programming Language :: Python :: Implementation :: CPython
     Programming Language :: Python :: Implementation :: PyPy
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,9 +1,6 @@
 import os
 
-try:
-    import unittest2 as unittest
-except ImportError:
-    import unittest
+import unittest
 
 
 def test_suite():

--- a/tests/base.py
+++ b/tests/base.py
@@ -9,10 +9,7 @@ import sys
 import time
 import types
 
-try:
-    import unittest2 as unittest
-except ImportError:
-    import unittest
+import unittest
 
 
 class PyangBindTestCase(unittest.TestCase):

--- a/tests/extmethods/run.py
+++ b/tests/extmethods/run.py
@@ -6,7 +6,6 @@ from tests.base import PyangBindTestCase
 
 
 class extmethodcls(object):
-
     def commit(self, *args, **kwargs):
         return "COMMIT_CALLED"
 
@@ -31,7 +30,7 @@ class ExtMethodsTests(PyangBindTestCase):
         self.instance = self.bindings.extmethods(extmethods={"/item/one": extmethodcls()})
 
     def test_extmethods_get_created_on_leafs(self):
-        for (method_name, valid) in [
+        for method_name, valid in [
             ("commit", True),
             ("presave", True),
             ("postsave", True),
@@ -43,7 +42,7 @@ class ExtMethodsTests(PyangBindTestCase):
                 self.assertEqual((method is not None), valid)
 
     def test_extmethods_return_expected_values(self):
-        for (method_name, retval) in [
+        for method_name, retval in [
             ("commit", "COMMIT_CALLED"),
             ("presave", "PRESAVE_CALLED"),
             ("postsave", "POSTSAVE_CALLED"),

--- a/tests/identityref/run.py
+++ b/tests/identityref/run.py
@@ -46,7 +46,7 @@ class IdentityRefTests(PyangBindTestCase):
                 self.assertTrue(allowed)
 
     def test_set_ancestral_identities_one(self):
-        for (identity, valid) in [
+        for identity, valid in [
             ("father", True),
             ("son", True),
             ("foo:father", True),
@@ -63,7 +63,7 @@ class IdentityRefTests(PyangBindTestCase):
                 self.assertEqual(allowed, valid)
 
     def test_set_ancestral_identities_two(self):
-        for (identity, valid) in [
+        for identity, valid in [
             ("grandmother", True),
             ("mother", True),
             ("niece", False),
@@ -83,7 +83,7 @@ class IdentityRefTests(PyangBindTestCase):
                 self.assertEqual(allowed, valid)
 
     def test_set_ancestral_identities_three(self):
-        for (identity, valid) in [("daughter", True), ("cousin", False), ("aunt", False)]:
+        for identity, valid in [("daughter", True), ("cousin", False), ("aunt", False)]:
             with self.subTest(identity=identity, valid=valid):
                 allowed = True
                 try:
@@ -93,7 +93,7 @@ class IdentityRefTests(PyangBindTestCase):
                 self.assertEqual(allowed, valid)
 
     def test_set_ancestral_identities_four(self):
-        for (identity, valid) in [
+        for identity, valid in [
             ("daughter", True),
             ("cousin", True),
             ("mother", True),
@@ -109,7 +109,7 @@ class IdentityRefTests(PyangBindTestCase):
                 self.assertEqual(allowed, valid)
 
     def test_grouping_identity_inheritance(self):
-        for (address_type, valid) in [("source-dest", True), ("lcaf", True), ("unknown", False)]:
+        for address_type, valid in [("source-dest", True), ("lcaf", True), ("unknown", False)]:
             with self.subTest(address_type=address_type, valid=valid):
                 allowed = True
                 try:
@@ -119,7 +119,7 @@ class IdentityRefTests(PyangBindTestCase):
                 self.assertEqual(allowed, valid)
 
     def test_set_identityref_from_imported_module(self):
-        for (identity, valid) in [
+        for identity, valid in [
             ("remote:remote-one", True),
             ("fordprefect:remote-one", False),
             ("remote:remote-two", True),
@@ -133,7 +133,7 @@ class IdentityRefTests(PyangBindTestCase):
                 self.assertEqual(allowed, valid)
 
     def test_set_identityref_from_imported_module_referencing_local(self):
-        for (identity, valid) in [("remote-id", True), ("remote-two:remote-id", True), ("invalid", False)]:
+        for identity, valid in [("remote-id", True), ("remote-two:remote-id", True), ("invalid", False)]:
             with self.subTest(identity=identity, valid=valid):
                 allowed = True
                 try:

--- a/tests/int/run.py
+++ b/tests/int/run.py
@@ -22,10 +22,10 @@ class IntTests(PyangBindTestCase):
 
     def test_default_values(self):
         for pair in [
-            ("eightdefault", 2 ** 7 - 1),
-            ("sixteendefault", 2 ** 15 - 1),
-            ("thirtytwodefault", 2 ** 31 - 1),
-            ("sixtyfourdefault", 2 ** 63 - 1),
+            ("eightdefault", 2**7 - 1),
+            ("sixteendefault", 2**15 - 1),
+            ("thirtytwodefault", 2**31 - 1),
+            ("sixtyfourdefault", 2**63 - 1),
         ]:
             with self.subTest(pair=pair):
                 default_val = getattr(self.int_obj.int_container, pair[0])._default
@@ -220,7 +220,7 @@ class IntTests(PyangBindTestCase):
                 self.assertIsNotNone(setter, "Could not find attribute setter for %s" % leaf)
 
     def test_set_int_sizes_at_lower_bounds(self):
-        bounds = {"eight": -2 ** 7, "sixteen": -2 ** 15, "thirtytwo": -2 ** 31, "sixtyfour": -2 ** 63}
+        bounds = {"eight": -(2**7), "sixteen": -(2**15), "thirtytwo": -(2**31), "sixtyfour": -(2**63)}
         for leaf, value in bounds.items():
             with self.subTest(leaf=leaf):
                 setter = getattr(self.int_obj.int_container, "_set_%s" % leaf)
@@ -232,7 +232,12 @@ class IntTests(PyangBindTestCase):
                 self.assertTrue(allowed, "Could not set int size %s to %d" % (leaf, value))
 
     def test_set_int_sizes_below_lower_bounds(self):
-        bounds = {"eight": -2 ** 7 - 1, "sixteen": -2 ** 15 - 1, "thirtytwo": -2 ** 31 - 1, "sixtyfour": -2 ** 63 - 1}
+        bounds = {
+            "eight": -(2**7) - 1,
+            "sixteen": -(2**15) - 1,
+            "thirtytwo": -(2**31) - 1,
+            "sixtyfour": -(2**63) - 1,
+        }
         for leaf, value in bounds.items():
             with self.subTest(leaf=leaf):
                 setter = getattr(self.int_obj.int_container, "_set_%s" % leaf)
@@ -244,7 +249,7 @@ class IntTests(PyangBindTestCase):
                 self.assertFalse(allowed, "Incorrectly set int size %s to %d" % (leaf, value))
 
     def test_set_int_sizes_at_upper_bounds(self):
-        bounds = {"eight": 2 ** 7 - 1, "sixteen": 2 ** 15 - 1, "thirtytwo": 2 ** 31 - 1, "sixtyfour": 2 ** 63 - 1}
+        bounds = {"eight": 2**7 - 1, "sixteen": 2**15 - 1, "thirtytwo": 2**31 - 1, "sixtyfour": 2**63 - 1}
         for leaf, value in bounds.items():
             with self.subTest(leaf=leaf):
                 setter = getattr(self.int_obj.int_container, "_set_%s" % leaf)
@@ -256,7 +261,7 @@ class IntTests(PyangBindTestCase):
                 self.assertTrue(allowed, "Could not set int size %s to %d" % (leaf, value))
 
     def test_set_int_sizes_above_upper_bounds(self):
-        bounds = {"eight": 2 ** 7, "sixteen": 2 ** 15, "thirtytwo": 2 ** 31, "sixtyfour": 2 ** 63}
+        bounds = {"eight": 2**7, "sixteen": 2**15, "thirtytwo": 2**31, "sixtyfour": 2**63}
         for leaf, value in bounds.items():
             with self.subTest(leaf=leaf):
                 setter = getattr(self.int_obj.int_container, "_set_%s" % leaf)
@@ -270,7 +275,7 @@ class IntTests(PyangBindTestCase):
     def test_set_int8_range_with_min_max_alias_to_lower_bound(self):
         allowed = True
         try:
-            self.int_obj.int_container.restricted_ueight_min_alias = -2 ** 7
+            self.int_obj.int_container.restricted_ueight_min_alias = -(2**7)
         except ValueError:
             allowed = False
         self.assertTrue(allowed, "Could not set min..max int8 to minimum value")
@@ -278,7 +283,7 @@ class IntTests(PyangBindTestCase):
     def test_set_int8_range_with_min_max_alias_to_upper_bound(self):
         allowed = True
         try:
-            self.int_obj.int_container.restricted_ueight_min_alias = 2 ** 7 - 1
+            self.int_obj.int_container.restricted_ueight_min_alias = 2**7 - 1
         except ValueError:
             allowed = False
         self.assertTrue(allowed, "Could not set min..max int8 to maximum value")
@@ -286,7 +291,7 @@ class IntTests(PyangBindTestCase):
     def test_set_int8_range_with_min_max_alias_below_lower_bound(self):
         allowed = True
         try:
-            self.int_obj.int_container.restricted_ueight_min_alias = -2 ** 7 - 1
+            self.int_obj.int_container.restricted_ueight_min_alias = -(2**7) - 1
         except ValueError:
             allowed = False
         self.assertFalse(allowed, "Incorrectly set min..max int8 to the min value minus one")
@@ -294,7 +299,7 @@ class IntTests(PyangBindTestCase):
     def test_set_int8_range_with_min_max_alias_above_upper_bound(self):
         allowed = True
         try:
-            self.int_obj.int_container.restricted_ueight_min_alias = 2 ** 7 + 1
+            self.int_obj.int_container.restricted_ueight_min_alias = 2**7 + 1
         except ValueError:
             allowed = False
         self.assertFalse(allowed, "Incorrectly set min..max int8 to the max value plus one")

--- a/tests/leaf-list/run.py
+++ b/tests/leaf-list/run.py
@@ -3,10 +3,7 @@ from __future__ import unicode_literals
 
 from tests.base import PyangBindTestCase
 
-try:
-    import unittest2 as unittest
-except ImportError:
-    import unittest
+import unittest
 
 
 class LeafListTests(PyangBindTestCase):

--- a/tests/list/run.py
+++ b/tests/list/run.py
@@ -80,7 +80,7 @@ class ListTests(PyangBindTestCase):
         self.assertEqual(len(self.instance.list_container.list_element), 0)
 
     def test_add_list_item_with_restricted_key(self):
-        for (animal, valid) in [("aardvark", True), ("bear", False), ("chicken", False)]:
+        for animal, valid in [("aardvark", True), ("bear", False), ("chicken", False)]:
             with self.subTest(animal=animal, valid=valid):
                 allowed = True
                 try:
@@ -90,7 +90,7 @@ class ListTests(PyangBindTestCase):
                 self.assertEqual(valid, allowed)
 
     def test_add_list_item_with_key_restricted_by_union_typedef(self):
-        for (animal, valid) in [("aardvark", True), ("bear", True), ("chicken", False)]:
+        for animal, valid in [("aardvark", True), ("bear", True), ("chicken", False)]:
             with self.subTest(animal=animal, valid=valid):
                 allowed = True
                 try:
@@ -100,7 +100,7 @@ class ListTests(PyangBindTestCase):
                 self.assertEqual(valid, allowed)
 
     def test_add_list_item_with_restricted_key_by_keyword(self):
-        for (food, valid) in [("broccoli", False), ("carrot", False), ("avocado", True)]:
+        for food, valid in [("broccoli", False), ("carrot", False), ("avocado", True)]:
             with self.subTest(food=food, valid=valid):
                 allowed = True
                 try:
@@ -115,7 +115,7 @@ class ListTests(PyangBindTestCase):
             self.instance.list_container.list_element[22].keyval = 14
 
     def test_adding_items_to_multi_key_list(self):
-        for (animal, valid) in [("aardvark 5", True), ("bear 7", True), ("chicken 5", False), ("bird 11", False)]:
+        for animal, valid in [("aardvark 5", True), ("bear 7", True), ("chicken 5", False), ("bird 11", False)]:
             with self.subTest(animal=animal, valid=valid):
                 allowed = True
                 try:
@@ -128,7 +128,7 @@ class ListTests(PyangBindTestCase):
         for i in range(1, 10):
             self.instance.list_container.list_five.add(i)
 
-        for (key, match) in zip(list(self.instance.list_container.list_five.keys()), range(1, 10)):
+        for key, match in zip(list(self.instance.list_container.list_five.keys()), range(1, 10)):
             with self.subTest(key=key, match=match):
                 self.assertEqual(key, match)
 
@@ -232,7 +232,7 @@ class ListTests(PyangBindTestCase):
         self.assertEqual(self.instance.list_nine[13].lv, "thirteen")
 
     def test_list_append_new_items_updates_keys(self):
-        for (key, val) in [(13, "thirteen"), ("fourteen", "14")]:
+        for key, val in [(13, "thirteen"), ("fourteen", "14")]:
             item = self.instance.list_nine._new_item()
             item.kv = key
             item.lv = val
@@ -248,7 +248,7 @@ class ListTests(PyangBindTestCase):
         self.assertEqual(self.instance.list_ten["12 13"].lv, "THIRTEEN")
 
     def test_list_append_new_items_with_compound_keys_updates_keys(self):
-        for (key1, key2, val) in [(12, 13, "THIRTEEN"), (13, 14, "FOURTEEN")]:
+        for key1, key2, val in [(12, 13, "THIRTEEN"), (13, 14, "FOURTEEN")]:
             item = self.instance.list_ten._new_item()
             item.kv = key1
             item.kvtwo = key2

--- a/tests/notification/run.py
+++ b/tests/notification/run.py
@@ -72,7 +72,7 @@ class NotificationTests(PyangBindTestCase):
 
         parent.test.reference_target.append("five")
 
-        for (value, valid) in [("five", True), ("fish", False)]:
+        for value, valid in [("five", True), ("fish", False)]:
             with self.subTest(value=value, valid=valid):
                 allowed = True
                 try:

--- a/tests/serialise/ietf-json-serialise/run.py
+++ b/tests/serialise/ietf-json-serialise/run.py
@@ -60,7 +60,7 @@ class IETFJSONDeserialiseTests(PyangBindTestCase):
         self.serialise_obj.c1.l1[1].typedef_one = "test"
         self.serialise_obj.c1.l1[1].typedef_two = 8
         self.serialise_obj.c1.l1[1].one_leaf = "hi"
-        self.serialise_obj.c1.l1[1].uint64type = 2 ** 22
+        self.serialise_obj.c1.l1[1].uint64type = 2**22
         self.serialise_obj.c1.l1[1].typedef_decimal = 32.29
         self.serialise_obj.c1.l1[1].typedef_decimalrange = Decimal("33.44")
         self.serialise_obj.c1.l1[1].range_decimal = Decimal("4.44443322")

--- a/tests/serialise/xml-serialise/run.py
+++ b/tests/serialise/xml-serialise/run.py
@@ -49,7 +49,7 @@ class XMLSerialiseTests(PyangBindTestCase):
         self.serialise_obj.c1.l1[1].typedef_one = "test"
         self.serialise_obj.c1.l1[1].typedef_two = 8
         self.serialise_obj.c1.l1[1].one_leaf = "hi"
-        self.serialise_obj.c1.l1[1].uint64type = 2 ** 22
+        self.serialise_obj.c1.l1[1].uint64type = 2**22
         self.serialise_obj.c1.l1[1].typedef_decimal = 32.29
         self.serialise_obj.c1.l1[1].typedef_decimalrange = Decimal("33.44")
         self.serialise_obj.c1.l1[1].range_decimal = Decimal("4.44443322")

--- a/tests/strings/run.py
+++ b/tests/strings/run.py
@@ -54,7 +54,7 @@ class StringTests(PyangBindTestCase):
             self.instance.string_container.restricted_string = "bear"
 
     def test_fixed_length_string(self):
-        for (value, valid) in [("a", False), ("ab", True), ("abc", False)]:
+        for value, valid in [("a", False), ("ab", True), ("abc", False)]:
             with self.subTest(value=value, valid=valid):
                 allowed = True
                 try:
@@ -64,7 +64,7 @@ class StringTests(PyangBindTestCase):
                 self.assertEqual(allowed, valid)
 
     def test_fixed_length_string_with_pattern(self):
-        for (value, valid) in [("a", False), ("ba", False), ("abc", False), ("ab", True)]:
+        for value, valid in [("a", False), ("ba", False), ("abc", False), ("ab", True)]:
             with self.subTest(value=value, valid=valid):
                 allowed = True
                 try:
@@ -74,7 +74,7 @@ class StringTests(PyangBindTestCase):
                 self.assertEqual(allowed, valid)
 
     def test_string_with_length_as_range_with_max(self):
-        for (value, valid) in [("short", False), ("loooooooong", True)]:
+        for value, valid in [("short", False), ("loooooooong", True)]:
             with self.subTest(value=value, valid=valid):
                 allowed = True
                 try:
@@ -84,7 +84,7 @@ class StringTests(PyangBindTestCase):
                 self.assertEqual(allowed, valid)
 
     def test_string_with_length_as_range_with_upper_bound(self):
-        for (value, valid) in [("short", False), ("loooooooong", True), ("toooooooooolooooooooong", False)]:
+        for value, valid in [("short", False), ("loooooooong", True), ("toooooooooolooooooooong", False)]:
             with self.subTest(value=value, valid=valid):
                 allowed = True
                 try:
@@ -94,7 +94,7 @@ class StringTests(PyangBindTestCase):
                 self.assertEqual(allowed, valid)
 
     def test_string_leaf_with_complex_length(self):
-        for (value, valid) in [
+        for value, valid in [
             ("strLength10", True),
             ("LengthTwelve", True),
             ("strTwentyOneCharsLong", False),
@@ -110,7 +110,7 @@ class StringTests(PyangBindTestCase):
                 self.assertEqual(allowed, valid)
 
     def test_string_leaf_pattern_with_dollar(self):
-        for (value, valid) in [("fi$h", True), ("void", False), ("fi$ho", True)]:
+        for value, valid in [("fi$h", True), ("void", False), ("fi$ho", True)]:
             with self.subTest(value=value, valid=valid):
                 allowed = True
                 try:
@@ -120,7 +120,7 @@ class StringTests(PyangBindTestCase):
                 self.assertEqual(allowed, valid)
 
     def test_string_leaf_pattern_with_dollar_at_end(self):
-        for (value, valid) in [("fi$h", True), ("void", False), ("fi$ho", False)]:
+        for value, valid in [("fi$h", True), ("void", False), ("fi$ho", False)]:
             with self.subTest(value=value, valid=valid):
                 allowed = True
                 try:

--- a/tests/typedef/run.py
+++ b/tests/typedef/run.py
@@ -12,7 +12,6 @@ class TypedefTests(PyangBindTestCase):
         self.typedef = self.bindings.typedef()
 
     def test_types(self):
-
         for element in [
             "string",
             "integer",

--- a/tests/uint/run.py
+++ b/tests/uint/run.py
@@ -14,11 +14,11 @@ class UIntTests(PyangBindTestCase):
         self.instance = self.bindings.uint()
 
     def test_uint_maximum_default_values(self):
-        for (size, value) in [
-            ("eight", 2 ** 8 - 1),
-            ("sixteen", 2 ** 16 - 1),
-            ("thirtytwo", 2 ** 32 - 1),
-            ("sixtyfour", 2 ** 64 - 1),
+        for size, value in [
+            ("eight", 2**8 - 1),
+            ("sixteen", 2**16 - 1),
+            ("thirtytwo", 2**32 - 1),
+            ("sixtyfour", 2**64 - 1),
         ]:
             with self.subTest(size=size, value=value):
                 default = getattr(self.instance.uint_container, "%sdefault" % size)._default
@@ -39,7 +39,7 @@ class UIntTests(PyangBindTestCase):
                 self.assertTrue(leaf_ref._changed())
 
     def test_uint8_with_restricted_range(self):
-        for (value, valid) in [(0, False), (7, True), (11, False)]:
+        for value, valid in [(0, False), (7, True), (11, False)]:
             with self.subTest(value=value, valid=valid):
                 allowed = True
                 try:
@@ -49,7 +49,7 @@ class UIntTests(PyangBindTestCase):
                 self.assertEqual(allowed, valid)
 
     def test_uint16_with_restricted_range(self):
-        for (value, valid) in [(99, False), (123, True), (1001, False)]:
+        for value, valid in [(99, False), (123, True), (1001, False)]:
             with self.subTest(value=value, valid=valid):
                 allowed = True
                 try:
@@ -59,7 +59,7 @@ class UIntTests(PyangBindTestCase):
                 self.assertEqual(allowed, valid)
 
     def test_uint32_with_restricted_range(self):
-        for (value, valid) in [(9999, False), (424242, True), (500001, False)]:
+        for value, valid in [(9999, False), (424242, True), (500001, False)]:
             with self.subTest(value=value, valid=valid):
                 allowed = True
                 try:
@@ -69,7 +69,7 @@ class UIntTests(PyangBindTestCase):
                 self.assertEqual(allowed, valid)
 
     def test_uint64_with_restricted_range(self):
-        for (value, valid) in [(799, False), (42424242, True), (18446744073709551615, False)]:
+        for value, valid in [(799, False), (42424242, True), (18446744073709551615, False)]:
             with self.subTest(value=value, valid=valid):
                 allowed = True
                 try:
@@ -79,7 +79,7 @@ class UIntTests(PyangBindTestCase):
                 self.assertEqual(allowed, valid)
 
     def test_additional_uint32_range(self):
-        for (value, valid) in [(0, True), (10, True), (2 ** 32 - 1, True), (2 ** 64, False)]:
+        for value, valid in [(0, True), (10, True), (2**32 - 1, True), (2**64, False)]:
             with self.subTest(value=value, valid=valid):
                 allowed = True
                 try:
@@ -107,7 +107,7 @@ class UIntTests(PyangBindTestCase):
                     setter(-1)
 
     def test_set_uint_values_above_upper_bounds(self):
-        bounds = {"eight": 2 ** 8, "sixteen": 2 ** 16, "thirtytwo": 2 ** 32, "sixtyfour": 2 ** 64}
+        bounds = {"eight": 2**8, "sixteen": 2**16, "thirtytwo": 2**32, "sixtyfour": 2**64}
         for size, value in bounds.items():
             with self.subTest(size=size, value=value), self.assertRaises(ValueError):
                 setter = getattr(self.instance.uint_container, "_set_%s" % size)

--- a/tests/union/run.py
+++ b/tests/union/run.py
@@ -70,7 +70,7 @@ class UnionTests(PyangBindTestCase):
         self.assertEqual(self.instance.container.u8._default, 10)
 
     def test_leaf_list_with_union_of_unions_from_typedefs(self):
-        for (value, valid) in [(1, True), ("hello", True), (42.42, True), (True, True), (bitarray(10), False)]:
+        for value, valid in [(1, True), ("hello", True), (42.42, True), (True, True), (bitarray(10), False)]:
             with self.subTest(value=value, valid=valid):
                 allowed = True
                 try:
@@ -80,7 +80,7 @@ class UnionTests(PyangBindTestCase):
                 self.assertEqual(allowed, valid)
 
     def test_leaf_list_with_union_of_unions_from_typedefs_with_restricted_types(self):
-        for (value, valid) in [
+        for value, valid in [
             (15, True),
             (35, True),
             ("aardvark", True),
@@ -102,7 +102,7 @@ class UnionTests(PyangBindTestCase):
         self.assertIsInstance(self.instance.container.u11._default, six.text_type)
 
     def test_union_of_restricted_class_types(self):
-        for (value, valid) in [("unlimited", True), (1, True), (0, True), ("fish", False), (2 ** 64, False)]:
+        for value, valid in [("unlimited", True), (1, True), (0, True), ("fish", False), (2**64, False)]:
             with self.subTest(value=value, valid=valid):
                 allowed = True
                 try:

--- a/tests/xpath/00_pathhelper_base.py
+++ b/tests/xpath/00_pathhelper_base.py
@@ -11,7 +11,6 @@ except ImportError:
 
 
 class TestObject(object):
-
     def __init__(self, name):
         self._name = name
 
@@ -20,7 +19,6 @@ class TestObject(object):
 
 
 class PathHelperBaseTests(unittest.TestCase):
-
     def setUp(self):
         self.tree = YANGPathHelper()
 

--- a/tests/xpath/00_pathhelper_base.py
+++ b/tests/xpath/00_pathhelper_base.py
@@ -4,10 +4,7 @@ from __future__ import print_function
 
 from pyangbind.lib.xpathhelper import XPathError, YANGPathHelper
 
-try:
-    import unittest2 as unittest
-except ImportError:
-    import unittest
+import unittest
 
 
 class TestObject(object):

--- a/tests/xpath/01-list_leaflist/run.py
+++ b/tests/xpath/01-list_leaflist/run.py
@@ -20,7 +20,7 @@ class XPathListLeaflistTests(PyangBindTestCase):
     def test_leaflist_leafref_with_require_instance_true(self):
         for fish in ["mackerel", "trout", "haddock", "flounder"]:
             self.instance.container.t1.append(fish)
-        for (fish, valid) in [("mackerel", True), ("haddock", True), ("minnow", False)]:
+        for fish, valid in [("mackerel", True), ("haddock", True), ("minnow", False)]:
             with self.subTest(fish=fish, valid=valid):
                 allowed = True
                 try:
@@ -32,7 +32,7 @@ class XPathListLeaflistTests(PyangBindTestCase):
     def test_leaflist_leafref_with_require_instance_false(self):
         for fish in ["mackerel", "trout", "haddock", "flounder"]:
             self.instance.container.t1.append(fish)
-        for (fish, exists) in [("flounder", True), ("minnow", False)]:
+        for fish, exists in [("flounder", True), ("minnow", False)]:
             with self.subTest(fish=fish, exists=exists):
                 allowed = True
                 try:
@@ -45,7 +45,7 @@ class XPathListLeaflistTests(PyangBindTestCase):
         for animal in ["kangaroo", "wallaby", "koala", "dingo"]:
             self.instance.container.t2.add(animal)
 
-        for (animal, valid) in [("kangaroo", True), ("koala", True), ("wombat", False)]:
+        for animal, valid in [("kangaroo", True), ("koala", True), ("wombat", False)]:
             with self.subTest(animal=animal, valid=valid):
                 allowed = True
                 try:
@@ -65,7 +65,7 @@ class XPathListLeaflistTests(PyangBindTestCase):
             self.instance.container.t3.append(beer)
 
         leaflist = self.path_helper.get("/container/t3")[0]
-        for (beer, valid) in [("session-ipa", True), ("amber-ale", True), ("moose-drool", False)]:
+        for beer, valid in [("session-ipa", True), ("amber-ale", True), ("moose-drool", False)]:
             with self.subTest(beer=beer, valid=valid):
                 found = True
                 try:
@@ -78,7 +78,7 @@ class XPathListLeaflistTests(PyangBindTestCase):
         for beer in ["oatmeal-stout", "amber-ale", "pale-ale", "pils", "ipa", "session-ipa"]:
             self.instance.container.t3.append(beer)
 
-        for (beer, valid) in [("session-ipa", True), ("amber-ale", True), ("moose-drool", False)]:
+        for beer, valid in [("session-ipa", True), ("amber-ale", True), ("moose-drool", False)]:
             with self.subTest(beer=beer, valid=valid):
                 removed = True
                 try:
@@ -104,7 +104,7 @@ class XPathListLeaflistTests(PyangBindTestCase):
         for beer in ["steam", "liberty", "california-lager", "porter", "ipa", "foghorn"]:
             self.instance.container.t4.add(beer)
 
-        for (beer, exists) in [("steam", 1), ("liberty", 1), ("pygmy-owl", 0)]:
+        for beer, exists in [("steam", 1), ("liberty", 1), ("pygmy-owl", 0)]:
             with self.subTest(beer=beer, exists=exists):
                 retr = self.path_helper.get("/container/t4[keyval=%s]" % beer)
                 self.assertEqual(len(retr), exists)
@@ -113,7 +113,7 @@ class XPathListLeaflistTests(PyangBindTestCase):
         for beer in ["steam", "liberty", "california-lager", "porter", "ipa", "foghorn"]:
             self.instance.container.t4.add(beer)
 
-        for (beer, valid) in [("steam", True), ("liberty", True), ("pygmy-owl", False)]:
+        for beer, valid in [("steam", True), ("liberty", True), ("pygmy-owl", False)]:
             with self.subTest(beer=beer, valid=valid):
                 removed = True
                 try:
@@ -142,7 +142,7 @@ class XPathListLeaflistTests(PyangBindTestCase):
         for city in ["quebec-city", "montreal", "laval", "gatineau"]:
             self.instance.container.t5.append(city)
 
-        for (city, valid) in [("quebec-city", True), ("montreal", True), ("dallas", False)]:
+        for city, valid in [("quebec-city", True), ("montreal", True), ("dallas", False)]:
             with self.subTest(city=city, valid=valid):
                 allowed = True
                 try:
@@ -155,7 +155,7 @@ class XPathListLeaflistTests(PyangBindTestCase):
         for beer in ["la-ciboire", "la-chipie", "la-joufflue", "la-matante"]:
             self.instance.container.t6.add(beer)
 
-        for (beer, valid) in [("la-ciboire", True), ("la-matante", True), ("heiniken", False)]:
+        for beer, valid in [("la-ciboire", True), ("la-matante", True), ("heiniken", False)]:
             with self.subTest(beer=beer, valid=valid):
                 allowed = True
                 try:
@@ -168,7 +168,7 @@ class XPathListLeaflistTests(PyangBindTestCase):
         for beer in ["snapshot", "ranger"]:
             self.instance.container.t7.append(beer)
 
-        for (beer, valid) in [("snapshot", True), ("ranger", True), ("trout-slayer", False)]:
+        for beer, valid in [("snapshot", True), ("ranger", True), ("trout-slayer", False)]:
             with self.subTest(beer=beer, valid=valid):
                 allowed = True
                 try:

--- a/tests/xpath/01-list_leaflist/run.py
+++ b/tests/xpath/01-list_leaflist/run.py
@@ -1,9 +1,6 @@
 #!/usr/bin/env python
 
-try:
-    import unittest2 as unittest
-except ImportError:
-    import unittest
+import unittest
 
 from pyangbind.lib.xpathhelper import YANGPathHelper
 from tests.base import PyangBindTestCase

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{27,34,35,36,37,py2},black
+envlist = py{37,38,39,310,311},black
 skip_missing_interpreters = True
 
 [testenv]
@@ -10,21 +10,10 @@ deps = -rrequirements.DEVELOPER.txt
 commands = coverage run -m pytest {posargs}
 
 [testenv:black]
-deps = black==18.5b0
+deps = black
 
-basepython = python3.6
 commands =
     black --check --line-length 119 .
-
-[travis]
-python =
-    2.7: py27
-    3.4: py34
-    3.5: py35
-    3.6: py36, black
-    3.7: py37
-    pypy2.7: pypy2
-    pypy3.5: pypy3
 
 [pytest]
 python_files = run.py


### PR DESCRIPTION
 * Indicate support for updated Python3 versions.
 * Remove Python2 and unittests2 dependency.
 * Update version of linter black, and lint the code accordingly.

No effective changes to pyangbind code behavior of PyPi package.