### PR TITLE
Skip known-failing tests, and block CI on fail.

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -34,6 +34,5 @@ jobs:
     - name: Run tox
       # Run tox using the version of Python in `PATH`
       run: tox -e py
-      continue-on-error: true
     - name: Build package
       run: python -m build

--- a/tox.ini
+++ b/tox.ini
@@ -33,3 +33,9 @@ testpaths =
 addopts = 
     --disable-warnings
     --import-mode importlib
+    # (TODO): https://github.com/robshakir/pyangbind/issues/304
+    --ignore=tests/binary
+    # (TODO): https://github.com/robshakir/pyangbind/issues/305
+    --ignore=tests/integration/openconfig-bgp
+    --ignore=tests/serialise/juniper-json-examples
+    


### PR DESCRIPTION
This allows the CI to detect and stop breaking changes, while the known-failing tests are fixed (issues raised for that).