### PR TITLE
Add step to install build for GithubAction

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -18,6 +18,8 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: "3.11"
+      - name: Install building dependencies
+        run: pip install build
       - name: Build package
         run: python -m build --sdist --wheel --outdir dist/
       - name: Publish package distributions to PyPI


### PR DESCRIPTION
I forgot that 'build' package needs to be installed in the GitHub Action environment.