### PR TITLE
Don't prefix a property value that is already prefixed

### DIFF
--- a/pyangbind/lib/serialise.py
+++ b/pyangbind/lib/serialise.py
@@ -235,7 +235,9 @@ class IETFYangDataSerialiser(YangDataSerialiser):
         try:
             emod = obj._enumeration_dict[obj]["@module"]
             if emod != obj._defining_module:
-                return "%s:%s" % (obj._enumeration_dict[obj]["@module"], obj)
+                # if not already prefixed with the type namespace
+                if not obj.startswith("%s" % emod):
+                    return "%s:%s" % (emod, obj)
         except KeyError:
             pass
         return six.text_type(obj)


### PR DESCRIPTION
This is a rebase of @markuscraig's PR #213 over the most recent master (original PR has a conflict when rebasing), plus a testcase that exhibits the issue.

Without the fix, testcase `test_json_ietf_serialise_namespace_handling_remote` fails with:

```
>               self.assertEqual(
                    data["identityref:ietfint"]["ref"],
                    "remote-two:remote-id",
                )
E               AssertionError: 'remote-two:remote-two:remote-id' != 'remote-two:remote-id'
E               - remote-two:remote-two:remote-id
E               ? -----------
E               + remote-two:remote-id
```

Reference: https://www.ietf.org/rfc/rfc6020.txt sections 9.10.*