### PR TITLE
Handle the "bits" type

### DIFF
--- a/docs/yang.md
+++ b/docs/yang.md
@@ -53,9 +53,9 @@ PyangBind does not currently try and be feature complete against the YANG langua
  **Type**            | **Sub-Statement**   | **Supported Type**      | **Unit Tests**
  --------------------|--------------------|--------------------------|---------------
  **binary**          | -                   | [bytes](https://docs.python.org/3/library/stdtypes.html?#bytes)           | tests/binary
- \-                   | length              | Supported           | tests/binary
- **bits**            | -                   | Not supported           | N/A
- \-                   | position            | Not supported           | N/A
+ \-                  | length              | Supported           | tests/binary
+ **bits**            | -                   | Set\[str\]              | tests/bits
+ \-                  | position            | Supported               |
  **boolean**         | -                   | YANGBool                | tests/boolean-empty
  **empty**           | -                   | YANGBool                | tests/boolean-empty
  **decimal64**       | -                   | [Decimal](https://docs.python.org/2/library/decimal.html) | tests/decimal64

--- a/pyangbind/lib/serialise.py
+++ b/pyangbind/lib/serialise.py
@@ -200,6 +200,8 @@ class YangDataSerialiser(object):
             return self.preprocess_element(obj.get())
         elif map_val in ["decimal.Decimal"]:
             return self.yangt_decimal(obj)
+        elif map_val in ["YANGBits"]:
+            return six.text_type(obj)
 
     def yangt_int(self, obj):
         # for values that are 32-bits and under..
@@ -686,7 +688,12 @@ class pybindJSONDecoder(object):
                 else:
                     # use the set method
                     pass
-            elif pybind_attr in ["RestrictedClassType", "ReferencePathType", "RestrictedPrecisionDecimal"]:
+            elif pybind_attr in [
+                "RestrictedClassType",
+                "ReferencePathType",
+                "RestrictedPrecisionDecimal",
+                "YANGBits",
+            ]:
                 # normal but valid types - which use the std set method
                 pass
             elif pybind_attr is None:

--- a/tests/bits/bits.yang
+++ b/tests/bits/bits.yang
@@ -1,0 +1,49 @@
+module bits {
+  yang-version 1.1;
+  namespace "http://rob.sh/yang/test/bits";
+  prefix "foo";
+  organization "BugReports Inc";
+  contact "A bug reporter";
+
+  description
+      "A test module";
+  revision 2014-01-01 {
+      description "april-fools";
+      reference "fooled-you";
+  }
+
+  // a typedef for bits, which is then applied to a leaf
+  typedef typedefed-bits {
+    type bits {
+      bit foo {
+	position 0;
+      }
+      bit bar {
+	position 1;
+      }
+      bit baz {
+	position 2;
+      }
+    }
+  }
+
+  leaf bits2 {
+    type typedefed-bits;
+  }
+
+  // a leaf containing the bits type definition
+  leaf mybits {
+    type bits {
+      bit flag1 {
+	position 0;
+      }
+      bit flag2 {
+	position 1;
+      }
+      bit flag3 {
+	position 2;
+      }
+    }
+    default "flag1 flag3";
+  }
+}

--- a/tests/bits/run.py
+++ b/tests/bits/run.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python
+from __future__ import unicode_literals
+
+import unittest
+
+from tests.base import PyangBindTestCase
+
+
+class BitsTests(PyangBindTestCase):
+    yang_files = ["bits.yang"]
+
+    def setUp(self):
+        self.instance = self.bindings.bits()
+
+    def test_default_bits(self):
+        self.assertEqual(
+            self.instance.mybits._default,
+            set(["flag1", "flag3"]),
+        )
+        self.assertFalse(self.instance.mybits._changed())
+
+    def test_default_bits_with_in(self):
+        self.assertTrue(
+            "flag1" in self.instance.mybits._default
+            and "flag2" not in self.instance.mybits._default
+            and "flag3" in self.instance.mybits._default
+        )
+
+    def test_default_bits_is_unchanged(self):
+        self.assertFalse(self.instance.mybits._changed())
+
+    def test_set_flags(self):
+        for value, valid in [("flag1", True), ("flag2", True), ("unknownflag", False)]:
+            with self.subTest(value=value, valid=valid):
+                allowed = True
+                try:
+                    self.instance.mybits.add(value)
+                except ValueError:
+                    allowed = False
+                self.assertEqual(allowed, valid)
+
+    def test_check_flags_unset(self):
+        self.instance.mybits.discard("flag2")
+        self.assertTrue("flag2" not in self.instance.mybits)
+        self.assertTrue(self.instance.mybits._changed())
+
+    def test_check_flags_set(self):
+        self.instance.bits2.add("foo")
+        self.assertTrue("foo" in self.instance.bits2)
+        self.assertEqual(set(["foo"]), self.instance.bits2)
+        self.assertTrue(self.instance.bits2._changed())
+
+    def test_bits_position(self):
+        self.instance.bits2.add("bar")
+        self.instance.bits2.add("baz")
+        self.instance.bits2.add("foo")
+        self.assertEqual(str(self.instance.bits2), "foo bar baz")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/serialise/json-deserialise/json-deserialise.yang
+++ b/tests/serialise/json-deserialise/json-deserialise.yang
@@ -171,6 +171,20 @@ module json-deserialise {
           }
         }
       }
+
+      leaf bits {
+        type bits {
+	  bit flag1 {
+	    position 1;
+	  }
+	  bit flag2 {
+	    position 2;
+	  }
+	  bit flag3 {
+	    position 3;
+	  }
+	}
+      }
     }
 
     list t1 {
@@ -189,5 +203,4 @@ module json-deserialise {
       type string;
     }
   }
-
 }

--- a/tests/serialise/json-deserialise/json/alltypes.json
+++ b/tests/serialise/json-deserialise/json/alltypes.json
@@ -35,7 +35,8 @@
                 "int8": 1, 
                 "uint64": 1, 
                 "int64": 1, 
-                "restricted-string": "aardvark"
+                "restricted-string": "aardvark",
+		"bits": "flag1 flag2"
             }
         }
     }

--- a/tests/serialise/json-deserialise/run.py
+++ b/tests/serialise/json-deserialise/run.py
@@ -79,6 +79,7 @@ class JSONDeserialiseTests(PyangBindTestCase):
                         "uint64": 1,
                         "int64": 1,
                         "restricted-string": "aardvark",
+                        "bits": set(["flag1", "flag2"]),
                     }
                 },
                 "t1": {"32": {"target": "32"}, "16": {"target": "16"}},

--- a/tests/serialise/json-serialise/json-serialise.yang
+++ b/tests/serialise/json-serialise/json-serialise.yang
@@ -199,6 +199,20 @@ module json-serialise {
         type decimalrangetype;
       }
 
+      leaf bits {
+        type bits {
+	  bit flag1 {
+	    position 1;
+	  }
+	  bit flag2 {
+	    position 2;
+	  }
+	  bit flag3 {
+	    position 3;
+	  }
+	}
+      }
+
       choice test-choice {
         case one {
           leaf one-leaf {

--- a/tests/serialise/json-serialise/json/expected-output.json
+++ b/tests/serialise/json-serialise/json/expected-output.json
@@ -78,7 +78,8 @@
                 "decleaf": 42.4422,
                 "typedef-decimal": 21.21,
                 "range-decimal": 4.44443322,
-                "typedef-decimalrange": 42.42
+                "typedef-decimalrange": 42.42,
+                "bits": "flag1 flag3"
             }
         }
     }

--- a/tests/serialise/json-serialise/run.py
+++ b/tests/serialise/json-serialise/run.py
@@ -63,6 +63,8 @@ class JSONSerialiseTests(PyangBindTestCase):
         self.serialise_obj.c1.l1[1].range_decimal = Decimal("4.44443322")
         self.serialise_obj.c1.l1[1].typedef_decimalrange = Decimal("42.42")
         self.serialise_obj.c1.l1[1].decleaf = Decimal("42.4422")
+        self.serialise_obj.c1.l1[1].bits.add("flag1")
+        self.serialise_obj.c1.l1[1].bits.add("flag3")
 
         for i in range(1, 10):
             self.serialise_obj.c1.l2.add(i)

--- a/tests/serialise/xml-deserialise/ietf-xml-deserialise.yang
+++ b/tests/serialise/xml-deserialise/ietf-xml-deserialise.yang
@@ -68,6 +68,17 @@ module ietf-xml-deserialise {
     }
   }
 
+  typedef typedef-bits {
+    type bits {
+      bit bit1 {
+	position 1;
+      }
+      bit bit2 {
+	position 2;
+      }
+    }
+  }
+
   container c1 {
     list l1 {
       key "k1";
@@ -237,6 +248,24 @@ module ietf-xml-deserialise {
 
       leaf uint64type {
         type derived64;
+      }
+
+      leaf typedefed-bits {
+	type typedef-bits;
+      }
+
+      leaf leaf-bits {
+	type bits {
+	  bit b1 {
+	    position 1;
+	  }
+	  bit b2 {
+	    position 2;
+	  }
+	  bit b3 {
+	    position 3;
+	  }
+	}
       }
     }
 

--- a/tests/serialise/xml-deserialise/xml/obj.xml
+++ b/tests/serialise/xml-deserialise/xml/obj.xml
@@ -39,6 +39,8 @@
       <range-decimal>4.44443322</range-decimal>
       <typedef-decimalrange>33.44</typedef-decimalrange>
       <uint64type>4194304</uint64type>
+      <typedefed-bits>bit1 bit2</typedefed-bits>
+      <leaf-bits>b1 b3</leaf-bits>
     </l1>
     <l2>
       <k1>1</k1>

--- a/tests/serialise/xml-serialise/ietf-xml-serialise.yang
+++ b/tests/serialise/xml-serialise/ietf-xml-serialise.yang
@@ -68,6 +68,17 @@ module ietf-xml-serialise {
     }
   }
 
+  typedef typedef-bits {
+    type bits {
+      bit bit1 {
+	position 1;
+      }
+      bit bit2 {
+	position 2;
+      }
+    }
+  }
+
   container c1 {
     list l1 {
       key "k1";
@@ -236,6 +247,24 @@ module ietf-xml-serialise {
 
       leaf uint64type {
         type derived64;
+      }
+
+      leaf typedefed-bits {
+	type typedef-bits;
+      }
+
+      leaf leaf-bits {
+	type bits {
+	  bit b1 {
+	    position 1;
+	  }
+	  bit b2 {
+	    position 2;
+	  }
+	  bit b3 {
+	    position 3;
+	  }
+	}
       }
     }
 

--- a/tests/serialise/xml-serialise/run.py
+++ b/tests/serialise/xml-serialise/run.py
@@ -59,6 +59,8 @@ class XMLSerialiseTests(PyangBindTestCase):
         self.serialise_obj.c1.l1[1].next_hop.append("TEST")
         self.serialise_obj.augtarget.augleaf = "teststring"
         self.serialise_obj.c1.l1[1].decleaf = Decimal("42.4422")
+        self.serialise_obj.c1.l1[1].typedefed_bits = "bit1 bit2"
+        self.serialise_obj.c1.l1[1].leaf_bits = "b1 b3"
         for i in range(1, 10):
             self.serialise_obj.c1.l2.add(i)
 

--- a/tests/serialise/xml-serialise/xml/obj.xml
+++ b/tests/serialise/xml-serialise/xml/obj.xml
@@ -38,6 +38,8 @@
       <range-decimal>4.44443322</range-decimal>
       <typedef-decimalrange>33.44</typedef-decimalrange>
       <uint64type>4194304</uint64type>
+      <typedefed-bits>bit1 bit2</typedefed-bits>
+      <leaf-bits>b1 b3</leaf-bits>
     </l1>
     <l2>
       <k1>1</k1>


### PR DESCRIPTION
The YANG "bits" type gets mapped to a `Set[str]` object in Python. The set object is augmented with a dictionary keeping track of the bit positions. This is used when forming the JSON or XML serialisation.


closes https://github.com/robshakir/pyangbind/issues/314