### PR TITLE
Optimisation: change class_map deepcopy to copy

### DIFF
--- a/pyangbind/plugin/pybind.py
+++ b/pyangbind/plugin/pybind.py
@@ -1550,7 +1550,7 @@ def get_element(ctx, fd, element, module, parent, path, parent_cfg=True, choice=
 
         # we need to indicate that the default type for the class_map
         # is str
-        tmp_class_map = copy.deepcopy(class_map)
+        tmp_class_map = copy.copy(class_map)
         tmp_class_map["enumeration"] = {"parent_type": "string"}
 
         if not default_type:


### PR DESCRIPTION
This is an improvement by a colleague of mine, @jamie01

pyangbind was taking around 18 seconds on my machine to create the classes for the collection of YANG models for a proprietary routing device. After doing some profiling, deepcopy operations were by far the worst offenders and in particular the deepcopy of "class_map" - a large structure containing all the yang types seen along the way.

Since the copied var doesn't modify deeply nested data, swapping it for a copy seemed reasonable. If I diff the python output file from deepcopy vs copy the files are identical. And not only that, the whole process now completes in under 4 seconds.