### PR TITLE
Add GitHub Action to build and bind with pyang

### DIFF
--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -5,7 +5,6 @@ name: Run TOX tests
 
 on:
   push:
-    branches: [ "master" ]
   pull_request:
     branches: [ "master" ]
 
@@ -20,7 +19,7 @@ jobs:
       run: pip install tox
     - name: Lint with black
       run: tox -e black
-  test:
+  unit-tests:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -38,3 +37,28 @@ jobs:
     - name: Run tox for ${{ matrix.python-version }}
       # Run tox using the version of Python in `PATH`
       run: tox -e py
+  int-tests:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v3
+      with:
+        python-version: ${{ matrix.python-version }}
+        cache: 'pip' # caching pip dependencies
+    - name: Install build dependencies
+      run: pip install build
+    - name: Build package
+      run: python -m build --wheel --outdir dist/
+    - name: Install package
+      run: pip install dist/pyangbind-*.whl
+    - name: Bind with pyang
+      run: |
+        export PYBINDPLUGIN=`/usr/bin/env python -c 'import pyangbind; import os; print ("{}/plugin".format(os.path.dirname(pyangbind.__file__)))'`
+        export PYTHONPATH=$PYTHONPATH:.
+        pyang --plugindir $PYBINDPLUGIN -f pybind -o tests/binding.py tests/base-test.yang
+    

--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -5,6 +5,7 @@ name: Run TOX tests
 
 on:
   push:
+    branches: [ "master" ]
   pull_request:
     branches: [ "master" ]
 
@@ -60,5 +61,5 @@ jobs:
       run: |
         export PYBINDPLUGIN=`/usr/bin/env python -c 'import pyangbind; import os; print ("{}/plugin".format(os.path.dirname(pyangbind.__file__)))'`
         export PYTHONPATH=$PYTHONPATH:.
-        pyang --plugindir $PYBINDPLUGIN -f pybind -o tests/binding.py tests/base-test.yang
+        pyang -V --plugindir $PYBINDPLUGIN -f pybind -o tests/binding.py tests/base-test.yang
     

--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -50,7 +50,6 @@ jobs:
       uses: actions/setup-python@v3
       with:
         python-version: ${{ matrix.python-version }}
-        cache: 'pip' # caching pip dependencies
     - name: Install build dependencies
       run: pip install build
     - name: Build package

--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,4 @@ tests/serialise/openconfig-serialise/include/
 tests/serialise/openconfig-serialise/ocbind/
 tests/serialise/openconfig-serialise/openconfig/
 tests/split-classes/bindings/
+tests/base-binding-out.py

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -19,12 +19,12 @@ fi
 pip install twine build
 python -m build --outdir $BASEDIR/dist/ $BASEDIR/
 
-pip install $BASEDIR/dist/pyangbind-*.whl
+pip install --force-reinstall $BASEDIR/dist/pyangbind-*.whl
 export PYBINDPLUGIN=`/usr/bin/env python -c \
 'import pyangbind; import os; print ("{}/plugin".format(os.path.dirname(pyangbind.__file__)))'`
-if ! pyang --plugindir $PYBINDPLUGIN -f pybind -o $BASEDIR/tests/binding.py $BASEDIR/tests/base-test.yang; then
+if ! pyang -V --plugindir $PYBINDPLUGIN -f pybind -o $BASEDIR/tests/base-binding-out.py $BASEDIR/tests/base-test.yang; then
     echo "FAILED: cannot bind with pyang"
     exit 126
 fi
 
-# python -m twine upload -s $BASEDIR/dist/pyangbind*
+python -m twine upload -s $BASEDIR/dist/pyangbind*

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -17,6 +17,14 @@ if [ $? -ne 0 ]; then
 fi
 
 pip install twine build
-python -m build --outdir $BASEDIR/dist/
+python -m build --outdir $BASEDIR/dist/ $BASEDIR/
 
-python -m twine upload -s $BASEDIR/dist/pyangbind*
+pip install $BASEDIR/dist/pyangbind-*.whl
+export PYBINDPLUGIN=`/usr/bin/env python -c \
+'import pyangbind; import os; print ("{}/plugin".format(os.path.dirname(pyangbind.__file__)))'`
+if ! pyang --plugindir $PYBINDPLUGIN -f pybind -o $BASEDIR/tests/binding.py $BASEDIR/tests/base-test.yang; then
+    echo "FAILED: cannot bind with pyang"
+    exit 126
+fi
+
+# python -m twine upload -s $BASEDIR/dist/pyangbind*


### PR DESCRIPTION
Add Jobs to the GitHub Action, to test that building and using the package with pyang works properly.

This is intended to discover issues not seen with tox unit tests.
Also, this installs all dependencies of pyangbind for different python versions.