### PR TITLE
Fix presence with SplitClassDir option, and containing Groups

### DIFF
--- a/pyangbind/lib/yangtypes.py
+++ b/pyangbind/lib/yangtypes.py
@@ -1091,7 +1091,7 @@ def YANGDynClass(*args, **kwargs):
             except TypeError:
                 super(YANGBaseClass, self).__init__()
             except Exception:
-                six.reraise()
+                raise
 
         def _changed(self):
             return self._mchanged
@@ -1205,6 +1205,8 @@ def YANGDynClass(*args, **kwargs):
             self._cpresent = present
             if present is True:
                 self._set()
+            if present is False:
+                self._mchanged = False
 
         def _present(self):
             if not self._is_container == "container":

--- a/pyangbind/plugin/pybind.py
+++ b/pyangbind/plugin/pybind.py
@@ -35,13 +35,7 @@ from pyang import plugin, statements, util
 
 import pyangbind.helpers.misc as misc_help
 from pyangbind.helpers.identity import IdentityStore
-from pyangbind.lib.yangtypes import (
-    RestrictedClassType,
-    YANGBool,
-    safe_name,
-    YANGBinary,
-    YANGBitsType,
-)
+from pyangbind.lib.yangtypes import RestrictedClassType, YANGBool, safe_name, YANGBinary, YANGBitsType
 
 # Python3 support
 if six.PY3:
@@ -1477,19 +1471,18 @@ def get_element(ctx, fd, element, module, parent, path, parent_cfg=True, choice=
 
         # Create an element for a container.
         has_presence = True if element.search_one("presence") is not None else False
-        if has_children or (ctx.opts.generate_presence and has_presence):
-            if has_children: 
-                get_children(
-                    ctx,
-                    fd,
-                    element.i_children,
-                    module,
-                    element,
-                    npath,
-                    parent_cfg=parent_cfg,
-                    choice=choice,
-                    register_paths=register_paths,
-                )
+        if element.i_children or (ctx.opts.generate_presence and has_presence):
+            get_children(
+                ctx,
+                fd,
+                element.i_children,
+                module,
+                element,
+                npath,
+                parent_cfg=parent_cfg,
+                choice=choice,
+                register_paths=register_paths,
+            )
 
             elemconfigdef = element.search_one("config")
             elemconfig = class_bool_map[elemconfigdef.arg] if elemconfigdef else True

--- a/pyangbind/plugin/pybind.py
+++ b/pyangbind/plugin/pybind.py
@@ -741,9 +741,6 @@ def get_children(ctx, fd, i_children, module, parent, path=str(), parent_cfg=Tru
         import_req = []
 
     for ch in i_children:
-        children_tmp = getattr(ch, "i_children", None)
-        if children_tmp is not None:
-            children_tmp = [i.arg for i in children_tmp]
         if ch.keyword == "choice":
             for choice_ch in ch.i_children:
                 # these are case statements
@@ -1479,23 +1476,20 @@ def get_element(ctx, fd, element, module, parent, path, parent_cfg=True, choice=
             npath = path
 
         # Create an element for a container.
-        if element.i_children or ctx.opts.generate_presence:
-            chs = element.i_children
-            has_presence = True if element.search_one("presence") is not None else False
-            if has_presence is False and len(chs) == 0:
-                return []
-
-            get_children(
-                ctx,
-                fd,
-                chs,
-                module,
-                element,
-                npath,
-                parent_cfg=parent_cfg,
-                choice=choice,
-                register_paths=register_paths,
-            )
+        has_presence = True if element.search_one("presence") is not None else False
+        if has_children or (ctx.opts.generate_presence and has_presence):
+            if has_children: 
+                get_children(
+                    ctx,
+                    fd,
+                    element.i_children,
+                    module,
+                    element,
+                    npath,
+                    parent_cfg=parent_cfg,
+                    choice=choice,
+                    register_paths=register_paths,
+                )
 
             elemconfigdef = element.search_one("config")
             elemconfig = class_bool_map[elemconfigdef.arg] if elemconfigdef else True

--- a/pyangbind/plugin/pybind.py
+++ b/pyangbind/plugin/pybind.py
@@ -774,9 +774,10 @@ def get_children(ctx, fd, i_children, module, parent, path=str(), parent_cfg=Tru
                 choice=choice,
                 register_paths=register_paths,
             )
-
             if ctx.opts.split_class_dir:
-                if hasattr(ch, "i_children") and len(ch.i_children):
+                if (hasattr(ch, "i_children") and len(ch.i_children)) or (
+                    ctx.opts.generate_presence and ch.search_one("presence")
+                ):
                     import_req.append(ch.arg)
 
     # Write out the import statements if needed.

--- a/tests/presence/presence.yang
+++ b/tests/presence/presence.yang
@@ -12,6 +12,12 @@ module presence {
         reference "fooled-you";
     }
 
+    grouping a-grouping {
+        leaf s {
+            type string;
+        }
+    }
+
     container empty-container {
         presence "something implied implicity";
     }
@@ -23,19 +29,23 @@ module presence {
     }
 
     container np-container {
-        description
-            "np container";
 
         leaf s {
             type string;
         }
     }
 
-    container pp {
+    container p-container {
         presence "implicit";
 
         leaf s {
             type string;
         }
+    }
+
+    container p-container-grouping {
+        presence "implicit";
+
+        uses a-grouping;
     }
 }

--- a/tests/presence/run.py
+++ b/tests/presence/run.py
@@ -16,10 +16,14 @@ class PresenceTests(PyangBindTestCase):
         self.instance = self.bindings.presence()
 
     def test_001_check_containers(self):
-        for attr in ["empty-container", 
-                     "parent", ["parent", "child"], 
-                     "np_container", "p_container", 
-                     "p_container_grouping"]:
+        for attr in [
+            "empty-container",
+            "parent",
+            ["parent", "child"],
+            "np_container",
+            "p_container",
+            "p_container_grouping",
+        ]:
             with self.subTest(attr=attr):
                 if isinstance(attr, list):
                     parent = self.instance
@@ -29,18 +33,18 @@ class PresenceTests(PyangBindTestCase):
                 else:
                     elem = getattr(self.instance, safe_name(attr), None)
                     self.assertIsNot(elem, None)
-    
+
     def test_002_check_leafs(self):
-        for attr in [("np_container", "s"),
-                     ("p_container",  "s"),
-                     ("p_container_grouping", "s"),
-                    ]:
+        for attr in [
+            ("np_container", "s"),
+            ("p_container", "s"),
+            ("p_container_grouping", "s"),
+        ]:
             with self.subTest(attr=attr):
                 container, leaf = attr
                 cont_elem = getattr(self.instance, container, None)
                 leaf_elem = getattr(cont_elem, leaf, None)
-                self.assertIsNotNone(leaf_elem, 
-                                     "Missing leaf %s in container %s" % (leaf, container))
+                self.assertIsNotNone(leaf_elem, "Missing leaf %s in container %s" % (leaf, container))
 
     def test_003_check_presence(self):
         self.assertIs(self.instance.empty_container._presence, True)

--- a/tests/presence/run.py
+++ b/tests/presence/run.py
@@ -16,7 +16,10 @@ class PresenceTests(PyangBindTestCase):
         self.instance = self.bindings.presence()
 
     def test_001_check_containers(self):
-        for attr in ["empty-container", "parent", ["parent", "child"]]:
+        for attr in ["empty-container", 
+                     "parent", ["parent", "child"], 
+                     "np_container", "p_container", 
+                     "p_container_grouping"]:
             with self.subTest(attr=attr):
                 if isinstance(attr, list):
                     parent = self.instance
@@ -26,33 +29,45 @@ class PresenceTests(PyangBindTestCase):
                 else:
                     elem = getattr(self.instance, safe_name(attr), None)
                     self.assertIsNot(elem, None)
+    
+    def test_002_check_leafs(self):
+        for attr in [("np_container", "s"),
+                     ("p_container",  "s"),
+                     ("p_container_grouping", "s"),
+                    ]:
+            with self.subTest(attr=attr):
+                container, leaf = attr
+                cont_elem = getattr(self.instance, container, None)
+                leaf_elem = getattr(cont_elem, leaf, None)
+                self.assertIsNotNone(leaf_elem, 
+                                     "Missing leaf %s in container %s" % (leaf, container))
 
-    def test_002_check_presence(self):
+    def test_003_check_presence(self):
         self.assertIs(self.instance.empty_container._presence, True)
         self.assertIs(self.instance.empty_container._cpresent, False)
         self.assertIs(self.instance.empty_container._present(), False)
 
-    def test_003_check_set_present(self):
+    def test_004_check_set_present(self):
         smt = getattr(self.instance.empty_container, "_set_present", None)
         self.assertIsNot(smt, None)
         smt()
         self.assertIs(self.instance.empty_container._cpresent, True)
         self.assertIs(self.instance.empty_container._present(), True)
 
-    def test_004_check_np(self):
+    def test_005_check_np(self):
         self.assertIs(self.instance.parent._presence, False)
         self.assertIs(self.instance.np_container._presence, False)
         self.assertIs(self.instance.np_container.s._presence, None)
 
-    def test_005_check_hierarchy(self):
-        self.assertIs(self.instance.pp._presence, True)
-        self.assertIs(self.instance.pp._present(), False)
-        self.assertIs(self.instance.pp._changed(), False)
-        self.instance.pp.s = "teststring"
-        self.assertIs(self.instance.pp._present(), True)
-        self.assertIs(self.instance.pp._changed(), True)
+    def test_006_check_hierarchy(self):
+        self.assertIs(self.instance.p_container._presence, True)
+        self.assertIs(self.instance.p_container._present(), False)
+        self.assertIs(self.instance.p_container._changed(), False)
+        self.instance.p_container.s = "teststring"
+        self.assertIs(self.instance.p_container._present(), True)
+        self.assertIs(self.instance.p_container._changed(), True)
 
-    def test_006_check_invalid_hierarchy(self):
+    def test_007_check_invalid_hierarchy(self):
         self.assertIs(self.instance.parent._presence, False)
         self.assertIs(self.instance.parent.child._presence, True)
         self.assertIs(self.instance.parent.child._present(), False)
@@ -60,23 +75,23 @@ class PresenceTests(PyangBindTestCase):
         self.assertIs(self.instance.parent.child._present(), True)
         self.assertIs(self.instance.parent._present(), None)
 
-    def test_007_set_not_present(self):
+    def test_008_set_not_present(self):
         self.instance.parent.child._set_present()
         self.assertIs(self.instance.parent.child._present(), True)
         self.instance.parent.child._set_present(present=False)
         self.assertIs(self.instance.parent.child._present(), False)
 
-    def test_008_presence_get(self):
+    def test_009_presence_get(self):
         self.instance.parent.child._set_present(True)
         self.assertIs(self.instance.empty_container._present(), False)
         self.assertIs(self.instance.parent.child._present(), True)
-        self.assertIs(self.instance.pp._present(), False)
+        self.assertIs(self.instance.p_container._present(), False)
         self.assertEqual(self.instance.get(filter=True), {"parent": {"child": {}}})
         self.instance.parent.child._set_present(False)
         self.assertIs(self.instance.parent.child._present(), False)
         self.assertEqual(self.instance.get(filter=True), {})
 
-    def test_009_presence_serialise(self):
+    def test_010_presence_serialise(self):
         self.instance.parent.child._set_present()
         expectedJ = """
                 {
@@ -89,7 +104,7 @@ class PresenceTests(PyangBindTestCase):
         expectedJ = "{}"
         self.assertEqual(json.loads(pbJ.dumps(self.instance)), json.loads(expectedJ))
 
-    def test_010_presence_serialise_ietf(self):
+    def test_011_presence_serialise_ietf(self):
         self.instance.parent.child._set_present()
         expectedJ = """
                 {
@@ -102,7 +117,7 @@ class PresenceTests(PyangBindTestCase):
         expectedJ = "{}"
         self.assertEqual(json.loads(pbJ.dumps(self.instance, mode="ietf")), json.loads(expectedJ))
 
-    def test_011_presence_deserialise(self):
+    def test_012_presence_deserialise(self):
         inputJ = """
               {
                 "parent": {
@@ -112,7 +127,7 @@ class PresenceTests(PyangBindTestCase):
         x = pbJ.loads(inputJ, self.bindings, "presence")
         self.assertIs(x.parent.child._present(), True)
 
-    def test_012_presence_deserialise(self):
+    def test_013_presence_deserialise(self):
         inputJ = """
               {
                 "presence:parent": {

--- a/tests/presence/run.py
+++ b/tests/presence/run.py
@@ -67,11 +67,14 @@ class PresenceTests(PyangBindTestCase):
         self.assertIs(self.instance.parent.child._present(), False)
 
     def test_008_presence_get(self):
-        self.instance.parent.child._set_present()
+        self.instance.parent.child._set_present(True)
         self.assertIs(self.instance.empty_container._present(), False)
         self.assertIs(self.instance.parent.child._present(), True)
         self.assertIs(self.instance.pp._present(), False)
         self.assertEqual(self.instance.get(filter=True), {"parent": {"child": {}}})
+        self.instance.parent.child._set_present(False)
+        self.assertIs(self.instance.parent.child._present(), False)
+        self.assertEqual(self.instance.get(filter=True), {})
 
     def test_009_presence_serialise(self):
         self.instance.parent.child._set_present()
@@ -82,8 +85,24 @@ class PresenceTests(PyangBindTestCase):
                     }
                 }"""
         self.assertEqual(json.loads(pbJ.dumps(self.instance)), json.loads(expectedJ))
+        self.instance.parent.child._set_present(False)
+        expectedJ = "{}"
+        self.assertEqual(json.loads(pbJ.dumps(self.instance)), json.loads(expectedJ))
 
-    def test_010_presence_deserialise(self):
+    def test_010_presence_serialise_ietf(self):
+        self.instance.parent.child._set_present()
+        expectedJ = """
+                {
+                    "presence:parent": {
+                        "child": {}
+                    }
+                }"""
+        self.assertEqual(json.loads(pbJ.dumps(self.instance, mode="ietf")), json.loads(expectedJ))
+        self.instance.parent.child._set_present(False)
+        expectedJ = "{}"
+        self.assertEqual(json.loads(pbJ.dumps(self.instance, mode="ietf")), json.loads(expectedJ))
+
+    def test_011_presence_deserialise(self):
         inputJ = """
               {
                 "parent": {
@@ -93,7 +112,7 @@ class PresenceTests(PyangBindTestCase):
         x = pbJ.loads(inputJ, self.bindings, "presence")
         self.assertIs(x.parent.child._present(), True)
 
-    def test_011_presence_deserialise(self):
+    def test_012_presence_deserialise(self):
         inputJ = """
               {
                 "presence:parent": {
@@ -102,6 +121,10 @@ class PresenceTests(PyangBindTestCase):
               }"""
         x = pbJ.loads_ietf(inputJ, self.bindings, "presence")
         self.assertIs(x.parent.child._present(), True)
+
+
+class SplitClassesPresenceTests(PresenceTests):
+    split_class_dir = True
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Likely solves https://github.com/robshakir/pyangbind/issues/336

- Correct encoding of a model instance after a presence container was set/unset.
- Generate correct python code with SplitClassDir option, when the model has Presence containers
- Render correctly Presence containers using groupings