### PR TITLE
Fix decoding xml blob with key that must follow a pattern

### DIFF
--- a/pyangbind/lib/yangtypes.py
+++ b/pyangbind/lib/yangtypes.py
@@ -297,9 +297,7 @@ def RestrictedClassType(*args, **kwargs):
 
             def match_pattern_check(regexp):
                 def mp_check(value):
-                    if not isinstance(value, six.string_types + (six.text_type,)):
-                        return False
-                    if regex.match(convert_regexp(regexp), value):
+                    if regex.match(convert_regexp(regexp), str(value)):
                         return True
                     return False
 
@@ -723,7 +721,7 @@ def YANGListType(*args, **kwargs):
                     self._members[k] = tmp
 
                 except ValueError as m:
-                    raise KeyError("key value must be valid, %s" % m)
+                    raise KeyError("key value %s must be valid, %s" % (self._keyval, m))
             else:
                 self._members[k] = YANGDynClass(
                     base=self._contained_class,

--- a/tests/serialise/xml-deserialise/ietf-xml-deserialise.yang
+++ b/tests/serialise/xml-deserialise/ietf-xml-deserialise.yang
@@ -296,6 +296,22 @@ module ietf-xml-deserialise {
         type int8;
       }
     }
+
+    list patternkey {
+      key "name";
+
+      leaf name {
+        type string {
+          pattern 'n.*';
+        }
+      }
+
+      leaf uid {
+        type string {
+          length 5..10;
+        }
+      }
+    }
   }
 
   container augtarget {

--- a/tests/serialise/xml-deserialise/xml/obj.xml
+++ b/tests/serialise/xml-deserialise/xml/obj.xml
@@ -83,6 +83,14 @@
       <leaf-one>bar</leaf-one>
       <leaf-two>2</leaf-two>
     </mkey>
+    <patternkey>
+      <name>not_a_name</name>
+      <uid>abcdef-hij</uid>
+    </patternkey>
+    <patternkey>
+      <name>name_me_not</name>
+      <uid>01234-45</uid>
+    </patternkey>
   </c1>
   <augtarget>
     <augleaf xmlns="http://rob.sh/yang/test/deserialise/ietf-xml-deserialise/augment">teststring</augleaf>


### PR DESCRIPTION
A fix for https://github.com/robshakir/pyangbind/issues/345

When decoding an XML blob, pyanbind was trying to check the pattern restriction on an lxml.objectify.StringElement object, which is not a native string type. 

With JSON decoding, this problem does not happen because the JSON value is a native str type.